### PR TITLE
Redesign master bedroom lights with a state-machine package

### DIFF
--- a/automations.yaml
+++ b/automations.yaml
@@ -29,36 +29,6 @@
         data: {}
         target:
           device_id: 4e798fe039ef3b748b3e8c867f3fcb68
-- id: '1748385723267'
-  alias: Master bedroom light dimmer switch
-  description: ''
-  use_blueprint:
-    path: patpac9/Hue_Dimmer_Switch_Easy_Custom_Buttons.yaml
-    input:
-      controller: Master bedroom wireless switch
-      up_released:
-      - action: script.toggle_blinds
-        metadata: {}
-        data: {}
-      on_released:
-      - action: scene.turn_on
-        metadata: {}
-        target:
-          entity_id: scene.master_bedroom_on
-        data: {}
-      off_released:
-      - action: light.turn_off
-        metadata: {}
-        data: {}
-        target:
-          entity_id: light.master_bedroom_lamp
-      down_released:
-      - action: scene.turn_on
-        metadata: {}
-        target:
-          entity_id: scene.master_bedroom_chill
-        data: {}
-      on_hold_released: []
 - id: '1760784792347'
   alias: Restart let's encrypt daily
   description: ''
@@ -188,14 +158,6 @@
     data:
       stop_actions: false
   mode: single
-- id: '1769862562265'
-  alias: Master bedroom lights copy main
-  description: ''
-  use_blueprint:
-    path: homeassistant/lamp_controls_area.yaml
-    input:
-      lamp_entity: light.master_bedroom_lamp
-      area: master_bedroom
 - id: '1769862562266'
   alias: Door opened alert
   description: ''
@@ -217,35 +179,4 @@
     metadata: {}
     data:
       message: The front door has opened
-  mode: single
-- id: '1771800062963'
-  alias: Master bedroom main switch
-  description: ''
-  triggers:
-  - domain: mqtt
-    device_id: 07ee2aa42b249d96057fbec264b7a25f
-    type: action
-    subtype: single_right
-    trigger: device
-  conditions: []
-  actions:
-  - type: toggle
-    device_id: e2e3433c00415e968dae6f242b09b5e0
-    entity_id: 33bdb23636411c0bffbbd01241f215cc
-    domain: light
-  mode: single
-- id: '1771800897993'
-  alias: Blinds to buttons
-  description: ''
-  triggers:
-  - domain: mqtt
-    device_id: 07ee2aa42b249d96057fbec264b7a25f
-    type: action
-    subtype: single_left
-    trigger: device
-  conditions: []
-  actions:
-  - action: script.toggle_blinds
-    metadata: {}
-    data: {}
   mode: single

--- a/packages/master_bedroom_lights.yaml
+++ b/packages/master_bedroom_lights.yaml
@@ -1,0 +1,280 @@
+---
+# Master Bedroom Lights Package
+#
+# Controls the master bedroom through three light "ingredients":
+#   - Lamp  (light.master_bedroom_lamp)               dimmable + colour
+#   - Main ceiling lights (light.master_bedroom_main_lights_right)  on/off only
+#   - Curtains (cover.master_bedroom_blinds, via script.toggle_blinds)
+#
+# DESIGN
+#   A single source of truth - input_select.master_bedroom_state - tracks the
+#   current lighting mode (full / dim / dim_low / off). Nothing makes one light
+#   blindly mirror another (that was the old `lamp_controls_area` blueprint, which
+#   caused the on/off cascade - it has been removed). Instead, small scripts apply
+#   one of three USER-EDITABLE scenes (defined in scenes.yaml so they can be tweaked
+#   in the HA Scene editor) and update the state tracker:
+#     scene.master_bedroom_full     - main lights on + lamp full
+#     scene.master_bedroom_dim      - lamp only, gently dimmed (~7%)
+#     scene.master_bedroom_dim_low  - lamp only, barely glowing (~1%)
+#
+# CONTROLS (behaviour is shared across both switches; the bedside one does more)
+#   Bedside switch - 4 buttons (Hue dimmer "Master bedroom wireless switch")
+#     on    -> Full (everything on)
+#     off   -> Everything off
+#     down  -> Cycle the dimmed modes:  dim -> dim_low -> off
+#     up    -> Toggle curtains
+#   Door switch - 2 buttons (Aqara)
+#     right -> Smart cycle through every mode:  off -> full -> dim -> dim_low -> off
+#     left  -> Toggle curtains
+#
+# STATE SYNC
+#   Two auxiliary automations keep the tracker honest if the lights are changed by
+#   other means (app, voice, the rain-warning package): turning the main lights on
+#   means "full", and everything going off means "off".
+#
+# RELATED
+#   The rain-warning package (packages/rain_warning.yaml) still flashes the lamp
+#   green/blue on the first morning turn-on. With the old cascade gone it no longer
+#   drags the main lights around.
+
+input_select:
+  master_bedroom_state:
+    name: Master Bedroom Lights State
+    options:
+      - "full"
+      - "dim"
+      - "dim_low"
+      - "off"
+    initial: "off"
+    icon: mdi:lightbulb-group
+
+script:
+
+  # ---------------------------------------------------------------------------
+  # Mode-setting building blocks. Each applies one scene and records the state.
+  # ---------------------------------------------------------------------------
+  master_bedroom_full:
+    alias: Master bedroom - full
+    icon: mdi:lightbulb-on
+    sequence:
+      - action: scene.turn_on
+        target:
+          entity_id: scene.master_bedroom_full
+        data:
+          transition: 1
+      - action: input_select.select_option
+        target:
+          entity_id: input_select.master_bedroom_state
+        data:
+          option: "full"
+
+  master_bedroom_dim:
+    alias: Master bedroom - dim
+    icon: mdi:lightbulb-on-30
+    sequence:
+      - action: scene.turn_on
+        target:
+          entity_id: scene.master_bedroom_dim
+        data:
+          transition: 2
+      - action: input_select.select_option
+        target:
+          entity_id: input_select.master_bedroom_state
+        data:
+          option: "dim"
+
+  master_bedroom_dim_low:
+    alias: Master bedroom - dim low
+    icon: mdi:lightbulb-on-10
+    sequence:
+      - action: scene.turn_on
+        target:
+          entity_id: scene.master_bedroom_dim_low
+        data:
+          transition: 2
+      - action: input_select.select_option
+        target:
+          entity_id: input_select.master_bedroom_state
+        data:
+          option: "dim_low"
+
+  master_bedroom_off:
+    alias: Master bedroom - all off
+    icon: mdi:lightbulb-off
+    sequence:
+      - action: light.turn_off
+        target:
+          entity_id:
+            - light.master_bedroom_lamp
+            - light.master_bedroom_main_lights_right
+        data:
+          transition: 1
+      - action: input_select.select_option
+        target:
+          entity_id: input_select.master_bedroom_state
+        data:
+          option: "off"
+
+  # ---------------------------------------------------------------------------
+  # Bedside "down" button: cycle through the dimmed modes only.
+  #   anything bright/off -> dim -> dim_low -> off
+  # ---------------------------------------------------------------------------
+  master_bedroom_dim_cycle:
+    alias: Master bedroom - cycle dim modes
+    icon: mdi:brightness-6
+    sequence:
+      - choose:
+          - conditions:
+              - condition: state
+                entity_id: input_select.master_bedroom_state
+                state: "dim"
+            sequence:
+              - action: script.master_bedroom_dim_low
+          - conditions:
+              - condition: state
+                entity_id: input_select.master_bedroom_state
+                state: "dim_low"
+            sequence:
+              - action: script.master_bedroom_off
+        default:
+          # From full or off, a press of "down" drops into the first dim level.
+          - action: script.master_bedroom_dim
+
+  # ---------------------------------------------------------------------------
+  # Door single button: smart cycle that reaches every mode with one button.
+  #   off -> full -> dim -> dim_low -> off
+  # ---------------------------------------------------------------------------
+  master_bedroom_main_cycle:
+    alias: Master bedroom - cycle all modes
+    icon: mdi:rotate-right
+    sequence:
+      - choose:
+          - conditions:
+              - condition: state
+                entity_id: input_select.master_bedroom_state
+                state: "off"
+            sequence:
+              - action: script.master_bedroom_full
+          - conditions:
+              - condition: state
+                entity_id: input_select.master_bedroom_state
+                state: "full"
+            sequence:
+              - action: script.master_bedroom_dim
+          - conditions:
+              - condition: state
+                entity_id: input_select.master_bedroom_state
+                state: "dim"
+            sequence:
+              - action: script.master_bedroom_dim_low
+          - conditions:
+              - condition: state
+                entity_id: input_select.master_bedroom_state
+                state: "dim_low"
+            sequence:
+              - action: script.master_bedroom_off
+        default:
+          - action: script.master_bedroom_full
+
+automation:
+
+  # ---------------------------------------------------------------------------
+  # BEDSIDE SWITCH (4 buttons) - Hue dimmer via the patpac9 blueprint.
+  # ---------------------------------------------------------------------------
+  - id: "1748385723267"
+    alias: Master bedroom bedside switch
+    description: 4-button bedside Hue dimmer - full / off / cycle-dim / curtains
+    use_blueprint:
+      path: patpac9/Hue_Dimmer_Switch_Easy_Custom_Buttons.yaml
+      input:
+        controller: Master bedroom wireless switch
+        on_released:
+          - action: script.master_bedroom_full
+        off_released:
+          - action: script.master_bedroom_off
+        down_released:
+          - action: script.master_bedroom_dim_cycle
+        up_released:
+          - action: script.toggle_blinds
+        on_hold_released: []
+
+  # ---------------------------------------------------------------------------
+  # DOOR SWITCH (2 buttons) - Aqara, raw MQTT device actions.
+  # ---------------------------------------------------------------------------
+  - id: "1771800062963"
+    alias: Master bedroom door switch - lights
+    description: Right button cycles off -> full -> dim -> dim_low -> off
+    triggers:
+      - domain: mqtt
+        device_id: 07ee2aa42b249d96057fbec264b7a25f
+        type: action
+        subtype: single_right
+        trigger: device
+    conditions: []
+    actions:
+      - action: script.master_bedroom_main_cycle
+    mode: single
+
+  - id: "1771800897993"
+    alias: Master bedroom door switch - curtains
+    description: Left button toggles the curtains
+    triggers:
+      - domain: mqtt
+        device_id: 07ee2aa42b249d96057fbec264b7a25f
+        type: action
+        subtype: single_left
+        trigger: device
+    conditions: []
+    actions:
+      - action: script.toggle_blinds
+    mode: single
+
+  # ---------------------------------------------------------------------------
+  # STATE SYNC: everything off
+  # If both the lamp and the main lights end up off by any means, record "off".
+  # 2s debounce lets scene transitions settle first.
+  # ---------------------------------------------------------------------------
+  - id: "1771800062964"
+    alias: Master bedroom - sync state when all lights off
+    description: Keep the tracker correct when lights are turned off externally
+    triggers:
+      - trigger: state
+        entity_id:
+          - light.master_bedroom_lamp
+          - light.master_bedroom_main_lights_right
+        to: "off"
+        for:
+          seconds: 2
+    conditions:
+      - condition: template
+        value_template: >
+          {{ states('light.master_bedroom_lamp') == 'off'
+             and states('light.master_bedroom_main_lights_right') == 'off' }}
+    actions:
+      - action: input_select.select_option
+        target:
+          entity_id: input_select.master_bedroom_state
+        data:
+          option: "off"
+    mode: single
+
+  # ---------------------------------------------------------------------------
+  # STATE SYNC: main lights on
+  # The main ceiling lights are only on in "full" mode, so if they come on by any
+  # means, record "full".
+  # ---------------------------------------------------------------------------
+  - id: "1771800062965"
+    alias: Master bedroom - sync state when main lights on
+    description: Keep the tracker correct when main lights are turned on externally
+    triggers:
+      - trigger: state
+        entity_id: light.master_bedroom_main_lights_right
+        to: "on"
+    conditions: []
+    actions:
+      - action: input_select.select_option
+        target:
+          entity_id: input_select.master_bedroom_state
+        data:
+          option: "full"
+    mode: single

--- a/scenes.yaml
+++ b/scenes.yaml
@@ -819,56 +819,15 @@
   icon: mdi:cards-heart
   metadata: {}
 - id: '1751324599554'
-  name: Master bedroom chill
+  name: Master bedroom dim
   entities:
+    # Dimmed mode: lamp only (gently dimmed), main ceiling lights off.
+    # Safe to tweak the brightness/colour in the Scene editor.
     light.master_bedroom_lamp:
-      min_color_temp_kelvin: 2000
-      max_color_temp_kelvin: 6535
-      min_mireds: 153
-      max_mireds: 500
-      effect_list:
-      - blink
-      - breathe
-      - okay
-      - channel_change
-      - finish_effect
-      - stop_effect
-      - colorloop
-      - stop_colorloop
-      supported_color_modes:
-      - color_temp
-      - xy
-      effect:
-      color_mode: color_temp
-      brightness: 18
-      color_temp_kelvin: 2000
-      color_temp: 500
-      hs_color:
-      - 30.601
-      - 94.547
-      rgb_color:
-      - 255
-      - 137
-      - 14
-      xy_color:
-      - 0.598
-      - 0.383
-      friendly_name: Master bedroom lamp
-      supported_features: 44
       state: 'on'
-    select.master_bedroom_mode_switch:
-      options:
-      - anti_flicker_mode
-      - quick_mode
-      icon: mdi:tune
-      friendly_name: Master bedroom main lights Mode switch
-      state: unknown
+      brightness: 18
+      color_temp: 500
     light.master_bedroom_main_lights_right:
-      supported_color_modes:
-      - onoff
-      color_mode:
-      friendly_name: Master bedroom main lights
-      supported_features: 0
       state: 'off'
   metadata: {}
 - id: '1767728852849'
@@ -986,55 +945,24 @@
   icon: mdi:desk-lamp
   metadata: {}
 - id: '1771801736357'
-  name: Master bedroom on
+  name: Master bedroom full
   entities:
+    # Everything on: main ceiling lights on, lamp at full warm-white brightness.
     light.master_bedroom_lamp:
-      min_color_temp_kelvin: 2000
-      max_color_temp_kelvin: 6535
-      min_mireds: 153
-      max_mireds: 500
-      effect_list:
-      - blink
-      - breathe
-      - okay
-      - channel_change
-      - finish_effect
-      - stop_effect
-      - colorloop
-      - stop_colorloop
-      supported_color_modes:
-      - color_temp
-      - xy
-      effect:
-      color_mode: color_temp
-      brightness: 3
-      color_temp_kelvin: 2000
-      color_temp: 500
-      hs_color:
-      - 30.601
-      - 94.547
-      rgb_color:
-      - 255
-      - 137
-      - 14
-      xy_color:
-      - 0.598
-      - 0.383
-      friendly_name: Master bedroom lamp
-      supported_features: 44
       state: 'on'
-    select.master_bedroom_mode_switch:
-      options:
-      - anti_flicker_mode
-      - quick_mode
-      icon: mdi:tune
-      friendly_name: Master bedroom main lights Mode switch
-      state: unknown
+      brightness: 255
+      color_temp: 370
     light.master_bedroom_main_lights_right:
-      supported_color_modes:
-      - onoff
-      color_mode: onoff
-      friendly_name: Master bedroom main lights
-      supported_features: 0
       state: 'on'
+  metadata: {}
+- id: '1771801736358'
+  name: Master bedroom dim low
+  entities:
+    # Really low: lamp barely glowing, main ceiling lights off.
+    light.master_bedroom_lamp:
+      state: 'on'
+      brightness: 3
+      color_temp: 500
+    light.master_bedroom_main_lights_right:
+      state: 'off'
   metadata: {}


### PR DESCRIPTION
Replace the buggy 'lamp follows main' coupling (the lamp_controls_area
blueprint) that caused the on/off cascade. Master bedroom lighting is now
driven by a single source of truth (input_select.master_bedroom_state) in
a new packages/master_bedroom_lights.yaml, applying three user-editable
scenes (full / dim / dim_low) kept in scenes.yaml so they remain tweakable
in the HA Scene editor.

Both switches share the same behaviour; the 4-button bedside switch does
more (full / off / cycle-dim / curtains), the 2-button door switch cycles
all modes and toggles curtains. State-sync automations keep the tracker
honest against app/voice/rain-warning changes.