### PR TITLE
Add motion-disable toggles for garden and living room

### DIFF
--- a/packages/living_room_lights.yaml
+++ b/packages/living_room_lights.yaml
@@ -27,6 +27,19 @@
 #   input_select.living_room_cosy_state is the source of truth for the current lighting mode.
 #   It is updated by the cosy cycle automation and kept in sync by two auxiliary automations
 #   that watch for lights being turned off externally or the main ceiling switch turning on.
+#
+# PRESENCE TOGGLE
+#   input_boolean.living_room_motion_enabled lets presence-based control be disabled from
+#   the dashboard (matching the motion toggles in the kitchen, bathroom, hallway and garden
+#   packages). While it is off, the presence sensor neither restores a scene on entry nor
+#   turns the lights off after the no-presence timeout; the manual button controls are
+#   unaffected.
+
+input_boolean:
+  living_room_motion_enabled:
+    name: Living Room Motion Enabled
+    icon: mdi:motion-sensor
+    initial: true
 
 input_select:
   living_room_cosy_state:
@@ -312,6 +325,16 @@ automation:
     - trigger: state
       entity_id: binary_sensor.living_room_presence_presence
       to: "on"
+    - trigger: state
+      entity_id: input_boolean.living_room_motion_enabled
+      to: "on"
+    conditions:
+    - condition: state
+      entity_id: input_boolean.living_room_motion_enabled
+      state: "on"
+    - condition: state
+      entity_id: binary_sensor.living_room_presence_presence
+      state: "on"
     actions:
     - choose:
         - conditions:
@@ -361,6 +384,10 @@ automation:
       to: "off"
       for:
         minutes: 30
+    conditions:
+    - condition: state
+      entity_id: input_boolean.living_room_motion_enabled
+      state: "on"
     actions:
     - action: light.turn_off
       target:

--- a/packages/motion_garden.yaml
+++ b/packages/motion_garden.yaml
@@ -2,7 +2,8 @@
 # Garden Motion Lighting Package
 #
 # Controls garden lights based on motion sensor and sun position.
-# Lights turn on when motion detected after sunset or before sunrise.
+# Lights turn on when motion detected after sunset or before sunrise,
+# provided motion control is enabled via the input_boolean toggle.
 # Timeout after motion stops controlled by input_number.motion_light_timeout,
 # max 2 hour runtime.
 #
@@ -12,6 +13,12 @@
 #
 # Dependencies:
 # - input_number.motion_light_timeout (defined in packages/motion_timeout.yaml)
+
+input_boolean:
+  garden_motion_enabled:
+    name: Garden Motion Enabled
+    icon: mdi:motion-sensor
+    initial: true
 
 automation:
   - id: gardenlightsmotinoandsun
@@ -24,7 +31,14 @@ automation:
       trigger: state
     - event: sunset
       trigger: sun
+    - entity_id:
+      - input_boolean.garden_motion_enabled
+      to: 'on'
+      trigger: state
     conditions:
+    - condition: state
+      entity_id: input_boolean.garden_motion_enabled
+      state: 'on'
     - condition: state
       entity_id: binary_sensor.garden_motion_occupancy
       state: 'on'


### PR DESCRIPTION
## Summary

Unifies the motion/presence-triggered lighting so **every** auto-lit area has a dashboard toggle to disable it, matching the existing pattern in the kitchen, bathroom and hallway packages.

Before this change, only the kitchen, bathroom and hallway had an `input_boolean` enable/disable helper. The **garden** and the **living room** (presence-controlled) did not, so there was no way to stop them auto-lighting from the dashboard. This change closes that gap.

## Changes

- **Garden** (`packages/motion_garden.yaml`)
  - Add `input_boolean.garden_motion_enabled` (name "Garden Motion Enabled", `mdi:motion-sensor`, `initial: true`).
  - Gate the motion/sun automation on the toggle with a condition, and add the toggle turning `on` as an extra trigger so re-enabling re-evaluates immediately.

- **Living room** (`packages/living_room_lights.yaml`)
  - Add `input_boolean.living_room_motion_enabled` (name "Living Room Motion Enabled", `mdi:motion-sensor`, `initial: true`).
  - Gate **both** presence automations on the toggle:
    - *restore state on entry* — also re-triggers when the toggle is turned back on.
    - *turn off after 30-minute no-presence timeout*.
  - The manual button controls (wall button, cosy button) are unaffected — only the presence sensor's automatic behaviour is disabled while the toggle is off.

## Approach / consistency

Each area's package already contains its own bespoke automation (garden has sun conditions, the living room has a cosy-state machine, etc.), so the simplest and most consistent option was to extend the existing per-package `<area>_motion_enabled` convention rather than force everything through a shared blueprint that couldn't capture those differences. All four toggles now share the same naming, icon and default, so they present uniformly on the dashboard.

The kitchen, bathroom and hallway packages already followed this pattern and are unchanged.

## Note on dashboards

Dashboards are in `storage` mode (managed in the HA UI; `.storage/` is git-ignored), so these new `input_boolean` helpers will need to be added to the relevant dashboard cards from the UI, exactly as the existing motion toggles were.

## Validation

Both changed files parse as valid YAML. Full validation requires a Home Assistant restart (custom `!include`/`!secret` tags can't be checked offline).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0135kZ2NaybMgiRzZXjLV7dS

---
_Generated by [Claude Code](https://claude.ai/code/session_0135kZ2NaybMgiRzZXjLV7dS)_