### PR TITLE
Vendor home-assistant-best-practices Claude skill

### DIFF
--- a/.claude/skills/home-assistant-best-practices/NOTICE.md
+++ b/.claude/skills/home-assistant-best-practices/NOTICE.md
@@ -1,0 +1,12 @@
+# Vendored skill
+
+This directory is vendored from [homeassistant-ai/skills](https://github.com/homeassistant-ai/skills),
+skill `home-assistant-best-practices` (metadata version 15), commit
+`191cfec77fb33a7e34a6f946bddfad68090324e4`, dated 2026-07-20.
+
+Licensed under MIT (see upstream `LICENSE`). The `evals/` directory from
+upstream was dropped since it's only needed for skill authoring/testing, not
+for using the skill.
+
+To update: re-clone the upstream repo, diff `skills/home-assistant-best-practices/`
+against this directory, and re-copy `SKILL.md` and `references/`.

--- a/.claude/skills/home-assistant-best-practices/SKILL.md
+++ b/.claude/skills/home-assistant-best-practices/SKILL.md
@@ -1,0 +1,146 @@
+---
+name: home-assistant-best-practices
+description: >
+  Best practices for HA automations, helpers, scripts, controls, and dashboards.
+
+  TRIGGER THIS SKILL WHEN:
+  - Creating or editing automations, scripts, scenes, or dashboards
+  - Choosing between template sensors and built-in helpers
+  - Restructuring triggers, conditions, or automation modes
+  - Setting up Zigbee button/remote automations
+  - Renaming entities or migrating device_id to entity_id
+  - Configuring dashboard cards or selecting helpers
+  - Looking up card types or domain docs
+  - Writing or reviewing AppDaemon apps
+  - Authoring or editing reusable Blueprints
+
+  SYMPTOMS:
+  - Agent uses Jinja2 templates where native options exist
+  - Agent uses device_id instead of entity_id
+  - Agent changes entity IDs without checking consumers
+  - Wrong automation mode
+  - Agent hard-codes values or uses raw sensor over helper
+  - Agent edits .storage, writes YAML, or generates YAML snippets
+  - Agent tells user to edit configuration.yaml for UI integrations
+  - Agent hardcodes entities in a Blueprint or uses free-text input over a selector
+metadata:
+  version: 15
+---
+
+# Home Assistant Best Practices
+
+**Core principle:** Use native Home Assistant constructs wherever possible. Templates bypass validation, fail silently at runtime, and make debugging opaque.
+
+## Decision Workflow
+
+Follow this sequence when creating any automation:
+
+### 0. Gate: modifying existing config?
+
+If your change affects entity IDs or cross-component references — renaming entities, replacing template sensors with helpers, converting device triggers, or restructuring automations — read `references/safe-refactoring.md` first. That reference covers impact analysis, device-sibling discovery, and post-change verification. Complete its workflow before proceeding.
+
+Steps 1-5 below apply to new config or pattern evaluation.
+
+### 1. Check for a purpose-specific, then generic native, trigger/condition
+Since 2026.7 the default building blocks are purpose-specific triggers/conditions — `<domain>.<name>` keys (motion detected, battery low, door opened) with area/floor/label targets. Check for one that matches the intent first, then a generic native trigger/condition, and only then a template. See `references/automation-patterns.md#purpose-specific-triggers--conditions-default-since-20267`.
+
+**Common substitutions:**
+- List of individual sensor entities in a trigger → one purpose-specific trigger with an area/floor/label `target:`
+- `{{ states('x') | float > 25 }}` → `numeric_state` condition with `above: 25`
+- `{{ is_state('x', 'on') and is_state('y', 'on') }}` → `condition: and` with state conditions
+- `{{ now().hour >= 9 }}` → `condition: time` with `after: "09:00:00"`
+- `wait_template: "{{ is_state(...) }}"` → `wait_for_trigger` with state trigger (caveat: different behavior when state is already true — see `references/safe-refactoring.md#trigger-restructuring`)
+
+### 2. Check for built-in helper or Template Helper
+Before creating a template sensor, check `references/helper-selection.md`.
+
+**Common substitutions:**
+- Sum/average multiple sensors → `min_max` integration
+- Binary any-on/all-on logic → `group` helper
+- Rate of change → `derivative` integration
+- Cross threshold detection → `threshold` integration
+- Consumption tracking → `utility_meter` helper
+
+**If no built-in helper fits, use a Template Helper — not YAML.**
+Create it via the HA config flow (MCP tool or API) or via the UI:
+Settings → Devices & Services → Helpers → Create Helper → Template.
+Only write `template:` YAML if explicitly requested or if neither path is available.
+
+### 3. Select correct automation mode
+Default `single` mode is often wrong. See `references/automation-patterns.md#automation-modes`.
+
+| Scenario | Mode |
+|----------|------|
+| Motion light with timeout | `restart` |
+| Sequential processing (door locks) | `queued` |
+| Independent per-entity actions | `parallel` |
+| One-shot notifications | `single` |
+
+### 4. Use entity_id over device_id
+`device_id` breaks when devices are re-added. See `references/device-control.md`.
+
+**Exception:** Zigbee2MQTT autodiscovered device triggers are acceptable.
+
+### 5. For Zigbee buttons/remotes
+- **ZHA:** Use `event` trigger with `device_ieee` (persistent)
+- **Z2M:** Use `device` trigger (autodiscovered) or `mqtt` trigger
+
+See `references/device-control.md#zigbee-buttonremote-patterns`.
+
+---
+
+## Critical Anti-Patterns
+
+| Anti-pattern | Use instead | Why | Reference |
+|--------------|-------------|-----|-----------|
+| `condition: template` with `float > 25` | `condition: numeric_state` | Validated at load, not runtime | `references/automation-patterns.md#native-conditions` |
+| `wait_template: "{{ is_state(...) }}"` | `wait_for_trigger` with state trigger | Event-driven, not polling; waits for *change* (see `references/safe-refactoring.md#trigger-restructuring` for semantic differences) | `references/automation-patterns.md#wait-actions` |
+| `device_id` in triggers | `entity_id` (or `device_ieee` for ZHA) | device_id breaks on re-add | `references/device-control.md#entity-id-vs-device-id` |
+| `mode: single` for motion lights | `mode: restart` | Re-triggers must reset the timer | `references/automation-patterns.md#automation-modes` |
+| `enabled: false` as a top-level key in `automations.yaml` | `automation.turn_off` (temporary) or entity registry disable (permanent) | Not a valid top-level key — rejected during schema validation; automation loads as `unavailable` | `references/automation-patterns.md#disabling-automations` |
+| Template sensor for sum/mean | `min_max` helper | Declarative, handles unavailable states | `references/helper-selection.md#numeric-aggregation` |
+| Template binary sensor with threshold | `threshold` helper | Built-in hysteresis support | `references/helper-selection.md#threshold` |
+| Renaming entity IDs without impact analysis | Follow `references/safe-refactoring.md` workflow | Renames break dashboards, scripts, scenes, Config-Entry data, and storage dashboards silently | `references/safe-refactoring.md#entity-renames` |
+| Renaming members of Config-Entry-based groups (UI groups) without updating membership | Update group membership via Options Flow after the registry rename | The entity registry rename does not update `options.entities` in the Config Entry — group silently breaks | `references/safe-refactoring.md#config-entry-groups` |
+| Renaming entities used by Config-Entry integrations (Better/Generic Thermostat, Min/Max, Threshold) without patching Config-Entry data | Scan and patch `core.config_entries` `data`+`options` fields | These integrations store entity_ids in Config Entry — not updated by entity registry renames | `references/safe-refactoring.md#config-entry-data--blind-spots-for-entity-registry-renames` |
+| `template:` sensor/binary sensor in YAML | Template Helper (UI or config flow API) | Requires file edit and config reload; harder to manage | `references/template-guidelines.md` |
+| Editing `.storage/` files or other HA internal state directly | Use the HA REST/WebSocket API to manage state and config entries | `.storage/` files are HA's internal state database; direct edits bypass validation, risk corruption, and can be silently overwritten by HA | — |
+| Writing raw YAML to `configuration.yaml` by hand for YAML-only integrations | Use managed YAML config editing with backup and validation | Unmanaged writes risk syntax errors, have no backup, and skip `check_config` — managed editing provides all three | `references/yaml-only-integrations.md` |
+| Generating YAML snippets for automations/scripts/scenes | Use the HA config API to create automations/scripts programmatically | API calls validate config, avoid syntax errors, and don't require manual file edits or restarts | `references/automation-patterns.md`, `references/examples.yaml` |
+| Telling user to edit `configuration.yaml` for integrations | Direct user to Settings > Devices & Services in the HA UI | Most integrations are UI-configured; YAML integration config is rare and integration-specific | — |
+| Referring to HA "add-ons" | Use the term "Apps" | HA renamed add-ons to Apps in 2026.2 — "Apps are standalone applications that run alongside Home Assistant" | — |
+| `vacuum.send_command` with vendor room IDs | `vacuum.clean_area` with HA `area_id` (if segments are mapped) | Uses native HA areas, works across integrations — but requires segment-to-area mapping in entity settings first | `references/device-control.md#vacuum-control` |
+| Using `color_temp` (mireds) in light service calls | Use `color_temp_kelvin` | The `color_temp` parameter was removed in 2026.3; only Kelvin is supported | `references/device-control.md#lights` |
+| Person/Device Tracker `entered_home`/`left_home` device triggers or `is_home`/`is_not_home` conditions | `state` trigger `to: home` / `to: not_home`, or `state` condition | These were removed in 2026.5 — state triggers and conditions are the correct replacements | `references/automation-patterns.md#presence-and-person-triggers-and-conditions-removed-in-20265` |
+| Entity list in a trigger where an area/floor/label target fits | Purpose-specific trigger with `target: {area_id: ...}` | Automation follows area membership as devices change — no stale entity lists | `references/automation-patterns.md#purpose-specific-triggers--conditions-default-since-20267` |
+| Old purpose-specific keys (`battery.low`, `vacuum.docked`, `timer.time_remaining`, ...) or trigger `behavior: any`/`last` | Renamed 2026.7 keys (`battery.became_low`, ...) and `behavior: each`/`all` | Old keys no longer load; old behavior values raise a repair issue and face removal | `references/automation-patterns.md#purpose-specific-triggers--conditions-default-since-20267` |
+| Registering callbacks or calling `self.turn_on()`/`self.get_state()` in `__init__()` | Register everything in `initialize()` | Plugin connection not established during `__init__` — calls fail silently | `references/appdaemon.md#app-structure-and-lifecycle` |
+| Calling `run_in` on repeated triggers without cancelling the previous handle | `cancel_timer(self._off_handle)` before each new `run_in` | Every trigger stacks an independent timer — devices toggle unpredictably | `references/appdaemon.md#scheduling-and-timers` |
+| Storing persistent state in instance variables | Use HA `input_number`, `input_boolean`, or `input_text` helpers | Instance variables reset on app reload or daemon restart | `references/appdaemon.md#state-management-and-inter-app-communication` |
+| Hardcoding entity IDs inside the class body | Pass entity IDs via `self.args` in `apps.yaml` | Hardcoded IDs prevent reuse and require code edits per installation | `references/appdaemon.md#appsyaml-configuration` |
+| Hardcoding entity IDs in a Blueprint body | Expose them as `!input` with a selector | Hardcoding defeats a blueprint's purpose — it can't be reused | `references/blueprint-guide.md#inputs-and-selectors` |
+| Free-text input for an entity/device in a Blueprint | Typed `entity`/`target`/`device` selector | Text lets typos through and fails silently; selectors validate the choice | `references/blueprint-guide.md#inputs-and-selectors` |
+| `!input` used directly inside a template | Bind it to a `variables:` entry, use the variable | `!input` is a YAML tag, not a template value — the template errors or ignores it | `references/blueprint-guide.md#referencing-inputs-input-and-templating` |
+| Publishing a Blueprint without `source_url` | Set `source_url` to the file's canonical URL | Without it users can't re-import updates and sharing is awkward | `references/blueprint-guide.md#blueprint-metadata` |
+
+---
+
+## Reference Files
+
+Read these when you need detailed information:
+
+| File | When to read | Key sections |
+|------|--------------|--------------|
+| `references/safe-refactoring.md` | Renaming entities, replacing helpers, restructuring automations, or any modification to existing config | `#universal-workflow`, `#entity-renames`, `#helper-replacements`, `#trigger-restructuring`, `#config-entry-data--blind-spots-for-entity-registry-renames`, `#storage-mode-dashboards-storagelovelace` |
+| `references/automation-patterns.md` | Writing triggers, conditions, waits, variables, or choosing automation modes; capturing action responses; documenting/annotating steps; disabling automations | `#purpose-specific-triggers--conditions-default-since-20267`, `#native-conditions`, `#trigger-types`, `#wait-actions`, `#automation-modes`, `#continue-on-error`, `#stopping-a-sequence`, `#variables`, `#capturing-action-responses`, `#repeat-actions`, `#ifthen-vs-choose`, `#parallel-actions`, `#trigger-ids`, `#documenting-automations--scripts`, `#disabling-automations` |
+| `references/helper-selection.md` | Deciding whether to use a built-in helper vs template sensor | `#how-helpers-are-created`, `#menu-based-helpers`, `#numeric-aggregation`, `#rate-and-change`, `#time-based-tracking`, `#counting-and-timing`, `#scheduling`, `#entity-grouping`, `#probabilistic-inference`, `#data-smoothing`, `#random-values`, `#climate-control`, `#domain-conversion`, `#template-helpers`, `#decision-matrix` |
+| `references/template-guidelines.md` | Confirming templates ARE appropriate for a use case | `#when-templates-are-appropriate`, `#when-to-avoid-templates`, `#template-sensor-best-practices`, `#common-patterns`, `#error-handling` |
+| `references/yaml-only-integrations.md` | Creating or editing YAML-only integrations that have no config flow (e.g. `command_line`, platform-based `mqtt`, `rest`) | `#yaml-only-integration-types`, `#post-edit-actions` |
+| `references/device-control.md` | Writing service calls, Zigbee button automations, or using target: | `#entity-id-vs-device-id`, `#service-calls-best-practices`, `#zigbee-buttonremote-patterns`, `#domain-specific-patterns` |
+| `references/scenes.md` | Authoring or activating scenes; snapshot/restore patterns; snapshot-vs-script distinction | `#scene-config-shape`, `#activating-a-scene`, `#snapshot--restore-scenecreate`, `#apply-states-without-storing-sceneapply` |
+| `references/dashboard-guide.md` | Designing or modifying Lovelace dashboards — layout, view types, strategies, sections, cards, badges, CSS styling, HACS | `#dashboard-structure`, `#view-types`, `#dashboard-strategies`, `#built-in-cards`, `#features`, `#badges`, `#custom-cards`, `#css-styling`, `#common-pitfalls` |
+| `references/dashboard-cards.md` | Looking up available card types or fetching card-specific documentation | — |
+| `references/domain-docs.md` | Looking up integration/domain documentation, or the dedicated doc page for a specific trigger, condition, or action | `#fetching-trigger-condition-and-action-docs` |
+| `references/examples.yaml` | Need compound examples combining multiple best practices | — |
+| `references/appdaemon.md` | AppDaemon apps: when to use vs. native HA, app structure, service calls, scheduling, error handling, safe refactoring impact | — |
+| `references/blueprint-guide.md` | Authoring reusable blueprints: metadata & `source_url`, inputs & selectors, `target` vs `entity`, defaults, input sections, `!input` templating, versioning | `#when-to-author-a-blueprint`, `#blueprint-metadata`, `#inputs-and-selectors`, `#target-selector-vs-entity-selector`, `#defaults`, `#input-sections`, `#referencing-inputs-input-and-templating`, `#versioning-and-updates`, `#common-pitfalls` |

--- a/.claude/skills/home-assistant-best-practices/references/appdaemon.md
+++ b/.claude/skills/home-assistant-best-practices/references/appdaemon.md
@@ -1,0 +1,537 @@
+# AppDaemon Best Practices
+
+AppDaemon is the right tool when native HA automations reach their limits: complex
+multi-step logic, stateful workflows, external API orchestration, or anything that
+benefits from a real programming language. It is **not** a replacement for HA
+automations in general — use it only when native tools are genuinely insufficient.
+
+
+## Table of Contents
+
+1. [When to Use AppDaemon (vs. Native HA)](#when-to-use-appdaemon-vs-native-ha)
+2. [App Structure and Lifecycle](#app-structure-and-lifecycle)
+3. [Listening to State Changes](#listening-to-state-changes)
+4. [Calling HA Services](#calling-ha-services)
+5. [Scheduling and Timers](#scheduling-and-timers)
+6. [State Management and Inter-App Communication](#state-management-and-inter-app-communication)
+7. [Logging](#logging)
+8. [apps.yaml Configuration](#appsyaml-configuration)
+9. [Error Handling](#error-handling)
+10. [AppDaemon-Specific Anti-Patterns](#appdaemon-specific-anti-patterns)
+11. [Impact on Safe Refactoring](#impact-on-safe-refactoring)
+12. [Post-Edit Actions](#post-edit-actions)
+
+
+## When to Use AppDaemon (vs. Native HA)
+
+| Situation | Recommended tool |
+| --------- | ---------------- |
+| Simple trigger → action | Native automation |
+| Condition chains, choose/if-then | Native automation |
+| Multi-step stateful logic (e.g. presence simulation)  | AppDaemon |
+| Looping, retries with backoff | AppDaemon |
+| External API orchestration (REST, polling, WebSocket) | AppDaemon |
+| Mathematical/statistical processing at runtime | AppDaemon |
+| Cross-entity coordination with shared in-memory state | AppDaemon |
+| Reusable logic applied to multiple entity groups | AppDaemon (parameterized class) |
+| Debugging complex timing issues with detailed logging | AppDaemon |
+
+**Anti-pattern:** Rewriting working HA automations in AppDaemon "for cleanliness."
+AppDaemon adds operational complexity (separate process, Python dependency, restart
+cycles) that is only justified when native automations genuinely cannot express the logic.
+
+## App Structure and Lifecycle
+
+Every AppDaemon app is a Python class that inherits from `Hass`:
+
+```python
+from appdaemon.plugins.hass import Hass
+
+class MyApp(Hass):
+
+    def initialize(self):
+        """Called once when AppDaemon starts or the app is reloaded."""
+        # Register callbacks here — not in __init__
+        self.listen_state(self.on_motion, "binary_sensor.hallway_motion", new="on")
+
+    def on_motion(self, entity, attribute, old, new, **kwargs):
+        """Callback signature: entity, attribute, old value, new value, **kwargs."""
+        self.turn_on("light.hallway")
+```
+
+**Rules:**
+
+- **Always register callbacks in `initialize()`**, never in `__init__()`. AppDaemon
+    calls `initialize()` after the plugin connection is established; `__init__()` runs
+    before that and HA API calls will fail silently.
+  
+    Store handles from `listen_state()`, `listen_event()`, or `run_*()` only if you need to cancel a specific listener or timer during runtime (e.g., for one-shot listeners). For reload safety, this is not required—AppDaemon automatically cleans up all listeners and timers on reload.
+
+## Listening to State Changes
+
+### Basic State Listener
+
+```python
+def initialize(self):
+    # Fire when entity changes to a specific state
+    self.listen_state(self.on_door_open, "binary_sensor.front_door", new="on")
+
+    # Fire on any state change
+    self.listen_state(self.on_temp_change, "sensor.living_room_temperature")
+
+    # Fire when a specific attribute changes
+    self.listen_state(
+        self.on_brightness_change,
+        "light.living_room",
+        attribute="brightness"
+    )
+
+    # Fire after entity has been in state for a duration (seconds)
+    self.listen_state(
+        self.on_motion_timeout,
+        "binary_sensor.hallway_motion",
+        new="off",
+        duration=300  # 5 minutes
+    )
+
+def on_door_open(self, entity, attribute, old, new, **kwargs):
+    self.log(f"{entity} changed from {old} to {new}")
+```
+
+### Passing Extra Arguments
+
+```python
+def initialize(self):
+    self.listen_state(
+        self.on_motion,
+        "binary_sensor.hallway_motion",
+        new="on",
+        light="light.hallway", # custom kwarg passed through to callback
+        brightness_pct=80
+    )
+
+def on_motion(self, entity, attribute, old, new, **kwargs):
+    self.turn_on(kwargs["light"], brightness_pct=kwargs["brightness_pct"])
+```
+
+### Getting Current State
+
+```python
+# Get state value
+state = self.get_state("binary_sensor.door") # "on" / "off"
+
+# Get a specific attribute
+brightness = self.get_state("light.living_room", attribute="brightness")
+
+# Get full state dict (includes 'state', 'attributes', 'last_changed', 'last_updated')
+attrs = self.get_state("light.living_room", attribute="all")
+
+# Safe numeric conversion — always guard against None / "unavailable"
+temp = self.get_state("sensor.temperature")
+if temp not in (None, "unavailable", "unknown"):
+    value = float(temp)
+```
+
+### Listening to Events
+
+```python
+def initialize(self):
+    # ZHA button event
+    self.listen_event(
+        self.on_zha_event,
+        "zha_event",
+        device_ieee="00:15:8d:00:07:26:f2:8a"
+    )
+
+def on_zha_event(self, event_name, data, **kwargs):
+    command = data.get("command")
+    if command == "toggle":
+        self.toggle("light.bedroom")
+```
+
+## Calling HA Services
+
+### turn_on / turn_off / toggle
+
+```python
+# Simple on/off/toggle
+self.turn_on("light.kitchen")
+self.turn_off("light.kitchen")
+self.toggle("light.kitchen")
+
+# With service data
+self.turn_on("light.kitchen", brightness_pct=80, color_temp_kelvin=3000)
+```
+
+### call_service
+
+Use `call_service` for any domain/service not covered by convenience methods.
+**Format: `domain/service_name` (slash, not dot).**
+
+```python
+# Climate
+self.call_service(
+    "climate/set_temperature",
+    entity_id="climate.living_room",
+    temperature=22,
+    hvac_mode="heat"
+)
+
+# Notify
+self.call_service(
+    "notify/mobile_app_phone",
+    title="Motion Detected",
+    message=f"Motion in hallway"
+)
+
+# Cover
+self.call_service(
+    "cover/set_cover_position",
+    entity_id="cover.living_room_blinds",
+    position=50
+)
+```
+
+### Targeting Areas
+
+```python
+# Turn off all lights in an area
+self.call_service(
+    "light/turn_off",
+    area_id="living_room"
+)
+```
+
+## Scheduling and Timers
+
+### One-Shot Delay
+
+```python
+def initialize(self):
+    self._off_handle = None
+    self.listen_state(self.on_motion, "binary_sensor.hallway_motion", new="on")
+
+def on_motion(self, entity, attribute, old, new, **kwargs):
+    # Cancel previous timer before scheduling a new one
+    if self._off_handle:
+        self.cancel_timer(self._off_handle)
+    self.turn_on("light.hallway")
+    self._off_handle = self.run_in(self.turn_off_cb, 300) # 300 seconds
+
+def turn_off_cb(self, **kwargs):
+    self.turn_off("light.hallway")
+    self._off_handle = None
+```
+
+**Anti-pattern:** Calling `run_in` from a motion callback without cancelling the
+previous handle first. Every motion event stacks a new independent timer — the light
+will switch off and potentially back on unpredictably. Always cancel first.
+
+### Recurring Schedules
+
+```python
+def initialize(self):
+    # Fixed time every day
+    self.run_daily(self.morning_routine, "07:00:00")
+
+    # Every N seconds (starting now)
+    self.run_every(self.poll_api, self.datetime(), 60)
+
+    # Sunrise / sunset with optional offset (seconds)
+    self.run_at_sunrise(self.on_sunrise)
+    self.run_at_sunset(self.on_sunset, offset=-1800) # 30 min before sunset
+```
+
+### Cancelling Handles
+
+```python
+def initialize(self):
+    self._state_handle = self.listen_state(self.on_change, "binary_sensor.door")
+    self._timer_handle = self.run_in(self.timeout_cb, 60)
+
+def cancel_manually(self):
+    if self._state_handle:
+        self.cancel_listen_state(self._state_handle)
+        self._state_handle = None
+    if self._timer_handle:
+        self.cancel_timer(self._timer_handle)
+        self._timer_handle = None
+```
+
+AppDaemon cancels all registered handles automatically when an app is unloaded or
+restarted. Manual cancellation is needed when you want to stop a specific callback
+mid-run based on logic conditions.
+
+## State Management and Inter-App Communication
+
+### Instance Variables (in-memory only)
+
+```python
+def initialize(self):
+    self._count = 0 # Reset on every app reload / daemon restart
+
+def on_trigger(self, entity, attribute, old, new, **kwargs):
+    self._count += 1
+    self.log(f"Triggered {self._count} times this session")
+```
+
+**Warning:** Instance variables are lost on hot-reload and daemon restart. For
+persistent state, use HA input helpers.
+
+### Persisting State via HA Helpers
+
+```python
+# Read
+raw_count = self.get_state("input_number.motion_counter")
+count = int(float(raw_count)) if raw_count not in (None, "unavailable", "unknown") else 0
+
+# Write
+self.call_service(
+    "input_number/set_value",
+    entity_id="input_number.motion_counter",
+    value=count + 1
+)
+
+# Boolean flag
+self.call_service(
+    "input_boolean/turn_on",
+    entity_id="input_boolean.presence_confirmed"
+)
+```
+
+### Inter-App Communication via Events
+
+```python
+# App A: fire a custom event (flat kwargs)
+self.fire_event("MY_APP_EVENT", source="app_a", value=42)
+
+# App B: subscribe to it
+def initialize(self):
+    self.listen_event(self.on_custom_event, "MY_APP_EVENT")
+
+def on_custom_event(self, event_name, data, **kwargs):
+    self.log(f"Received from {data['source']}: {data['value']}")
+```
+
+## Logging
+
+```python
+self.log("Normal operational message") # INFO (default)
+self.log("Detailed debug info", level="DEBUG")
+self.log("Something unexpected happened", level="WARNING")
+self.log("Service call failed", level="ERROR")
+```
+
+**Best practices:**
+
+- Include entity names and current values in log messages so `appdaemon.log` is
+  readable without cross-referencing the HA state history.
+- Use `level="DEBUG"` for high-frequency state change details; keep `INFO` for
+  meaningful transitions only.
+- Avoid expensive f-string expressions at `DEBUG` level in hot paths — guard with
+  a condition if the expression requires additional `get_state()` calls.
+
+## apps.yaml Configuration
+
+### Basic App Entry
+
+```yaml
+# /config/appdaemon/apps/apps.yaml
+
+motion_light_hallway:
+  module: motion_light # Python filename without .py
+  class: MotionLight # Class name inside the file
+  entity_motion: binary_sensor.hallway_motion
+  entity_light: light.hallway
+  timeout: 300
+```
+
+### Parameterized App — Multiple Instances
+
+Define the logic once in Python, instantiate multiple times in `apps.yaml`:
+
+```python
+# motion_light.py
+from appdaemon.plugins.hass import Hass
+
+class MotionLight(Hass):
+
+    def initialize(self):
+        # Ensure required args are present
+        for required in ("entity_light", "entity_motion"):
+            if required not in self.args:
+                self.log(f"{required} is required in apps.yaml", level="ERROR")
+                return
+        self._light   = self.args["entity_light"]
+        self._timeout = self.args.get("timeout", 180)
+        self._off_handle = None
+        self.listen_state(
+            self.on_motion,
+            self.args["entity_motion"],
+            new="on"
+        )
+
+    def on_motion(self, entity, attribute, old, new, **kwargs):
+        if self._off_handle:
+            self.cancel_timer(self._off_handle)
+        self.turn_on(self._light)
+        self._off_handle = self.run_in(self.turn_off_cb, self._timeout)
+
+    def turn_off_cb(self, **kwargs):
+        self.turn_off(self._light)
+        self._off_handle = None
+```
+
+```yaml
+# apps.yaml
+
+motion_light_hallway:
+  module: motion_light
+  class: MotionLight
+  entity_motion: binary_sensor.hallway_motion
+  entity_light: light.hallway
+  timeout: 300
+
+motion_light_kitchen:
+  module: motion_light
+  class: MotionLight
+  entity_motion: binary_sensor.kitchen_motion
+  entity_light: light.kitchen
+  timeout: 120
+```
+
+This parameterized pattern is a primary AppDaemon strength: no code duplication,
+entity IDs stay in configuration rather than source code.
+
+### Packages (Subdirectory Organisation)
+
+```
+/config/appdaemon/apps/
+  lighting/
+    __init__.py        # required when using dotted module paths; not needed for flat module names
+    motion_light.py
+  presence/
+    __init__.py  # required for dotted module paths
+    tracker.py
+```
+
+```yaml
+motion_light_hallway:
+  module: lighting.motion_light
+  class: MotionLight
+  entity_motion: binary_sensor.hallway_motion
+  entity_light: light.hallway
+```
+
+## Error Handling
+
+### Defensive State Reads
+
+```python
+def get_temperature(self):
+    raw = self.get_state("sensor.outside_temperature")
+    if raw in (None, "unavailable", "unknown"):
+        self.log("Temperature sensor unavailable", level="WARNING")
+        return None
+    try:
+        return float(raw)
+    except (ValueError, TypeError):
+        self.log(f"Unexpected temperature value: {raw!r}", level="ERROR")
+        return None
+```
+
+### Accessing args Safely
+
+```python
+def initialize(self):
+    # Use .get() with a default rather than direct key access
+    self._timeout   = self.args.get("timeout", 180)
+    self._log_level = self.args.get("log_level", "INFO")
+
+    # Required args: fail loudly with a clear message
+    if "entity_light" not in self.args:
+        self.log("entity_light is required in apps.yaml", level="ERROR")
+        return
+    self._light = self.args["entity_light"]
+```
+
+### Verifying Service Call Outcomes
+
+AppDaemon does not raise exceptions for failed service calls. Verify critical
+outcomes by reading entity state after a short delay:
+
+```python
+def initialize(self):
+    # ...existing code...
+    self._verify_handle = None
+
+def set_thermostat(self, temp):
+    self.call_service(
+        "climate/set_temperature",
+        entity_id="climate.living_room",
+        temperature=temp
+    )
+    if hasattr(self, "_verify_handle") and self._verify_handle:
+        self.cancel_timer(self._verify_handle)
+    self._verify_handle = self.run_in(self.verify_thermostat, 5, expected=temp)
+
+def verify_thermostat(self, **kwargs):
+    actual = self.get_state("climate.living_room", attribute="temperature")
+    if actual in (None, "unavailable", "unknown"):
+        self.log("Could not verify thermostat — sensor unavailable", level="WARNING")
+        return
+    expected = kwargs.get("expected")
+    if expected is None:
+        self.log("verify_thermostat called without expected — cannot verify", level="ERROR")
+        return
+    if abs(float(actual) - float(expected)) > 0.5:
+        self.log(
+            f"Thermostat did not accept setpoint {expected} "
+            f"(actual: {actual})",
+            level="WARNING"
+        )
+```
+
+## AppDaemon-Specific Anti-Patterns
+
+| Anti-pattern | Use instead | Why |
+| ------------ | ----------- | --- |
+| Calling `self.turn_on()` / `self.get_state()` in `__init__()` | Register everything in `initialize()` | Plugin connection not established during `__init__` — calls fail silently |
+| Calling `run_in` on repeated triggers without cancelling the previous handle | `cancel_timer(self._off_handle)` before each new `run_in` | Every trigger stacks an independent timer — devices toggle unpredictably |
+| Storing persistent state in instance variables | Use HA `input_number`, `input_boolean`, or `input_text` helpers  | Instance variables reset on app reload or daemon restart |
+| Hardcoding entity IDs inside the class body | Pass entity IDs via `self.args` in `apps.yaml` | Hardcoded IDs prevent reuse and require code edits per installation |
+| Accessing `self.get_state()` result without guarding for `"unavailable"` / `"unknown"` | `if new not in (None, "unavailable", "unknown")` | Unavailable sensors cause `float()` / `int()` to raise `ValueError` |
+| Polling state with a tight `run_every` loop | `listen_state` with `duration` parameter | Polling wastes CPU and bloats the log; `listen_state(duration=N)` is event-driven |
+| call_service("light.turn_on", ...) — dot notation | call_service("light/turn_on", ...) — slash notation | AppDaemon requires domain/service format; dot notation will cause the call to silently do nothing or log a warning, depending on the version. |
+| `self.args["key"]` without `.get()` | `self.args.get("key", default)` | Missing key in `apps.yaml` raises `KeyError` at startup with no useful error message |
+| Writing a new AppDaemon app for logic that native HA can express | Use native automation, `choose`, `repeat`, or `wait_for_trigger` | AppDaemon adds a separate process, Python dependency, and longer restart cycle |
+
+## Impact on Safe Refactoring
+
+AppDaemon apps reference HA entity IDs as string literals in Python files **and**
+as argument values in `apps.yaml`. When renaming HA entities, search AppDaemon
+sources in addition to the standard HA config components listed in
+`references/safe-refactoring.md#step-2-search-all-consumers`.
+
+**Additional locations to include in the Step 2 checklist:**
+
+| Location | What to search |
+| -------- | -------------- |
+| `/config/appdaemon/apps/**/*.py` | Old entity ID as a string literal or default in `self.args.get(...)` |
+| `/config/appdaemon/apps/apps.yaml` | Old entity ID as a value in any app argument |
+
+After updating, hot-reload is automatic (AppDaemon watches file changes). Confirm
+in `appdaemon.log` that the app reloaded without errors.
+
+## Post-Edit Actions
+
+| Change type | Required action |
+| ----------- | --------------- |
+| New or edited `.py` app file | AppDaemon hot-reloads automatically on file save (requires `production_mode: false`, which is the default) |
+| Edit to `apps.yaml` | Hot-reload automatic; verify in `appdaemon.log` |
+| Edit to `appdaemon.yaml` (daemon config) | Restart the AppDaemon App — **Settings → Apps → AppDaemon → Restart** |
+| HA entity rename consumed by an app | Update all `.py` files and `apps.yaml`; hot-reload triggers automatically |
+| New Python package dependency | Add to AppDaemon App configuration (`python_packages` list) and restart the App |
+
+**Note:** In HA 2026.2+, add-ons are referred to as **Apps**. The AppDaemon add-on
+appears under **Settings → Apps**.

--- a/.claude/skills/home-assistant-best-practices/references/automation-patterns.md
+++ b/.claude/skills/home-assistant-best-practices/references/automation-patterns.md
@@ -1,0 +1,1219 @@
+# Automation Patterns
+
+This document covers native Home Assistant automation constructs that should be used instead of templates.
+
+## Table of Contents
+1. [Native Conditions](#native-conditions)
+2. [Trigger Types](#trigger-types)
+3. [Wait Actions](#wait-actions)
+4. [Automation Modes](#automation-modes)
+5. [Continue on Error](#continue-on-error)
+6. [Stopping a Sequence](#stopping-a-sequence)
+7. [Variables](#variables)
+8. [Capturing Action Responses](#capturing-action-responses)
+9. [Repeat Actions](#repeat-actions)
+10. [if/then vs choose](#ifthen-vs-choose)
+11. [Parallel Actions](#parallel-actions)
+12. [Trigger IDs](#trigger-ids)
+13. [Documenting Automations & Scripts](#documenting-automations--scripts)
+14. [Disabling Automations](#disabling-automations)
+
+---
+
+## Native Conditions
+
+### State Condition
+
+The most common condition type. Supports multiple states, attributes, and duration.
+
+```yaml
+# Single state
+condition: state
+entity_id: light.living_room
+state: "on"
+
+# Multiple acceptable states (OR logic)
+condition: state
+entity_id: vacuum.robot
+state:
+  - "cleaning"
+  - "returning"
+
+# Attribute check
+condition: state
+entity_id: climate.thermostat
+attribute: hvac_action
+state: "heating"
+
+# Duration check (entity has been in state for X time)
+condition: state
+entity_id: binary_sensor.motion
+state: "off"
+for:
+  minutes: 5
+```
+
+### Numeric State Condition
+
+For numeric comparisons. Always prefer over template conditions with `| float`.
+
+```yaml
+# Above threshold
+condition: numeric_state
+entity_id: sensor.temperature
+above: 25
+
+# Below threshold
+condition: numeric_state
+entity_id: sensor.humidity
+below: 30
+
+# Range
+condition: numeric_state
+entity_id: sensor.battery
+above: 20
+below: 80
+
+# Attribute numeric check
+condition: numeric_state
+entity_id: sun.sun
+attribute: elevation
+below: -6
+```
+
+### Time Condition
+
+For time-based restrictions. Handles midnight crossing automatically.
+
+```yaml
+# Time range (handles midnight crossing!)
+condition: time
+after: "22:00:00"
+before: "06:00:00"
+
+# Weekday filter
+condition: time
+weekday:
+  - mon
+  - tue
+  - wed
+  - thu
+  - fri
+
+# Combined
+condition: time
+after: "09:00:00"
+before: "17:00:00"
+weekday:
+  - mon
+  - tue
+  - wed
+  - thu
+  - fri
+```
+
+> **A one-sided window anchors at midnight — it does not carve a slot out of the day.**
+> A `condition: time` with only `before: "21:00:00"` is true from **00:00 to 21:00**, so it still
+> matches 01:00, 04:00 and 06:00; with only `after: "21:00:00"` it is true from 21:00 to midnight.
+> To restrict to daytime, give **both** bounds (`after: "06:00:00"` *and* `before: "21:00:00"`).
+> A window spans midnight only when `after` is later than `before` (e.g. `after: "22:00:00"`,
+> `before: "06:00:00"`).
+
+### Sun Condition
+
+For sunrise/sunset-based logic with optional offsets.
+
+```yaml
+# After sunset
+condition: sun
+after: sunset
+
+# Before sunrise with offset
+condition: sun
+before: sunrise
+before_offset: "01:00:00"
+
+# After sunset by 30 minutes
+condition: sun
+after: sunset
+after_offset: "00:30:00"
+```
+
+### Zone Condition
+
+For presence detection based on zones.
+
+```yaml
+condition: zone
+entity_id: person.john
+zone: zone.home
+
+# Or check if NOT in zone
+condition: not
+conditions:
+  - condition: zone
+    entity_id: person.john
+    zone: zone.home
+```
+
+### And/Or/Not Conditions
+
+Combine conditions with logical operators.
+
+```yaml
+# AND (default when multiple conditions listed)
+condition: and
+conditions:
+  - condition: state
+    entity_id: light.kitchen
+    state: "on"
+  - condition: numeric_state
+    entity_id: sensor.brightness
+    below: 100
+
+# OR
+condition: or
+conditions:
+  - condition: state
+    entity_id: person.john
+    state: "home"
+  - condition: state
+    entity_id: person.jane
+    state: "home"
+
+# NOT
+condition: not
+conditions:
+  - condition: state
+    entity_id: alarm_control_panel.home
+    state: "armed_away"
+
+# Shorthand syntax
+conditions:
+  - and:
+      - condition: state
+        entity_id: input_boolean.guest_mode
+        state: "on"
+      - condition: time
+        after: "08:00:00"
+```
+
+### Template Condition Shorthand
+
+When you must use a template, use the shorthand syntax:
+
+```yaml
+# Shorthand (preferred when template is necessary)
+conditions:
+  - "{{ trigger.to_state.attributes.brightness > 100 }}"
+
+# Long form (equivalent)
+conditions:
+  - condition: template
+    value_template: "{{ trigger.to_state.attributes.brightness > 100 }}"
+```
+
+### Trigger Condition
+
+Matches *which* trigger started the run, by trigger `id` — the clean way to branch on the trigger (see [Trigger IDs](#trigger-ids)) instead of templating `trigger.id`. Only true when the run was started by a trigger (false in scripts and manual runs).
+
+```yaml
+condition: trigger
+id: motion_on        # a single id, or a list (OR semantics):
+# id:
+#   - motion_on
+#   - motion_off
+```
+
+---
+
+## Trigger Types
+
+### Purpose-Specific Triggers & Conditions (default since 2026.7)
+
+HA organizes triggers and conditions by real-world intent (motion detected, door opened, battery low, temperature crossed threshold) rather than by technical entity domain. Introduced in 2026.2 and expanded each release, this family **left Labs and became the default automation-building experience in 2026.7**. It is not UI-only sugar: these are first-class config — `trigger: <domain>.<name>` / `condition: <domain>.<name>` with `target:` and `options:` blocks — and round-trip through the config API like any other automation config. (The step-level `note:` field is separate additive syntax — see [Documenting Automations & Scripts](#documenting-automations--scripts).)
+
+```yaml
+triggers:
+  - trigger: motion.detected
+    target:
+      area_id: living_room        # entity_id / device_id / area_id / floor_id / label_id
+    options:
+      behavior: each              # multi-target semantics: each (default) / first / all
+      for: "00:00:30"             # optional dwell time
+conditions:
+  - condition: battery.is_low
+    target:
+      label_id: critical_devices
+    options:
+      behavior: any               # conditions combine with any (default) / all
+```
+
+**Prefer these over the generic triggers below when one matches the intent:**
+
+- **Targets, not entity lists.** Target an area/floor/label ("motion in the living room") and the automation follows area membership as sensors are added, swapped, or removed — no entity list to maintain. This also replaces most remaining legitimate uses of device triggers.
+- **No `unavailable`/`unknown` traps.** Each block handles unavailable states and event-entity re-fire quirks internally.
+- **Cross-entity-type.** "Door opened" fires whether the door is a contact sensor or a motorized cover.
+- **Integration-extensible.** Integrations register their own (e.g. `zwave_js.*`), so the catalog grows over time.
+
+**Multi-target `behavior` enums differ between triggers and conditions:**
+
+- Triggers: `each` (default) / `first` / `all`. The pre-2026.7 values `any` and `last` were renamed to `each` and `all` — they still work but raise a repair issue and face removal. Never emit them (some official doc pages still show the old values mid-migration).
+- Conditions: `any` (default) / `all` — unchanged.
+
+**Keys renamed in 2026.7 (trigger keys unless marked *(condition)*) — old keys no longer work:**
+
+| Old | New |
+|-----|-----|
+| `battery.low` | `battery.became_low` |
+| `battery.not_low` | `battery.no_longer_low` |
+| `lawn_mower.docked` | `lawn_mower.returned_to_dock` |
+| `schedule.turned_on` | `schedule.block_started` |
+| `schedule.turned_off` | `schedule.block_ended` |
+| `timer.time_remaining` | `timer.remaining_time_reached` |
+| `update.update_became_available` | `update.became_available` |
+| `vacuum.docked` | `vacuum.returned_to_dock` |
+| `climate.target_temperature` (condition) | `climate.is_target_temperature` |
+| `climate.target_humidity` (condition) | `climate.is_target_humidity` |
+
+**Discovering what exists:** every purpose-specific trigger and condition (and every service action) has a dedicated documentation page covering its config shape, options, and examples — fetch it on demand instead of guessing keys; see `domain-docs.md#fetching-trigger-condition-and-action-docs`. The trees span 50+ domains (~190 trigger and ~145 condition pages, generic types included): battery, motion, occupancy, door/window/gate/garage_door, climate, media_player, sun, timer, schedule, vacuum, lawn_mower, zone, and more. 2026.7 added the sun family (`sun.dawn`, `sun.dusk`, `sun.solar_noon`, `sun.solar_midnight`, elevation triggers).
+
+Since 2026.7, `options.for` durations on **conditions** are primed from recorded history, so a freshly created or reloaded condition does not restart its duration clock from zero. Trigger `for:` clocks still reset as described in [`for:` duration resets](#for-duration-resets-on-restart-and-on-unavailable).
+
+The generic triggers below remain fully supported and are the right choice when no purpose-specific block matches the intent (attribute changes, template-derived conditions, webhooks, MQTT, etc.). As with everything in this file, create and update automations through the config API — the YAML shows the config shape, not a file to hand-edit.
+
+### State Trigger
+
+The workhorse trigger. Fires on entity state changes.
+
+```yaml
+# Basic state change to specific value
+triggers:
+  - trigger: state
+    entity_id: binary_sensor.motion
+    to: "on"
+
+# From specific state
+triggers:
+  - trigger: state
+    entity_id: light.bedroom
+    from: "off"
+    to: "on"
+
+# Any state change (omit to/from)
+triggers:
+  - trigger: state
+    entity_id: sensor.temperature
+
+# Attribute change
+triggers:
+  - trigger: state
+    entity_id: climate.thermostat
+    attribute: current_temperature
+
+# Duration trigger (entity has been in state for X)
+triggers:
+  - trigger: state
+    entity_id: light.porch
+    to: "on"
+    for:
+      minutes: 30
+
+# Multiple entities
+triggers:
+  - trigger: state
+    entity_id:
+      - binary_sensor.motion_kitchen
+      - binary_sensor.motion_hallway
+    to: "on"
+```
+
+### Numeric State Trigger
+
+Fires when crossing a threshold.
+
+```yaml
+triggers:
+  - trigger: numeric_state
+    entity_id: sensor.temperature
+    above: 25
+    for:
+      minutes: 5
+```
+
+### `for:` duration resets on restart and on `unavailable`
+
+A `for:` clause (on `state` / `numeric_state` triggers, and on the `state` condition) measures
+**continuous** time the entity has held the matching state. The clock resets to zero whenever that
+continuity breaks — including two cases that are easy to miss:
+
+- **Every Home Assistant restart.** On restart the state is *restored* but `last_changed` is
+  re-stamped to start-up time, so the duration clock restarts from zero. The same applies to
+  `{{ now() - x.last_changed }}` duration math in templates.
+- **A momentary `unavailable`.** Cloud-, Wi-Fi- and hub-backed entities routinely flick to
+  `unavailable` for a few seconds; each blip resets the clock.
+
+So a long `for:` (e.g. several hours) is **unreliable as a safety backstop** — frequent restarts or
+blips keep knocking it back and it may never reach the threshold.
+
+**Robust pattern:** stamp a persistent `input_datetime` on the *genuine* transition you care about,
+then gate on elapsed time since the stamp:
+
+```yaml
+# 1. On the real transition, record when it happened:
+triggers:
+  - trigger: state
+    entity_id: climate.bedroom
+    from: "off"
+    to: "cool"
+actions:
+  - action: input_datetime.set_datetime
+    target:
+      entity_id: input_datetime.cooling_started
+    data:
+      datetime: "{{ now() }}"
+
+# 2. Elsewhere, test elapsed time — the timestamp attribute is restart- and unavailable-proof:
+conditions:
+  - "{{ state_attr('input_datetime.cooling_started', 'timestamp') is not none and now().timestamp() - state_attr('input_datetime.cooling_started', 'timestamp') >= 10800 }}"
+```
+
+An `input_datetime` restores its value across restarts and is untouched by `unavailable` blips, so
+only the real start/stop events move it.
+
+**Diagnosing:** if a `last_changed` looks wrong, compare it against a stable entity such as `sun.sun`.
+When several entities' `last_changed` all jumped to the same time — one that isn't sunrise/sunset —
+that was a restart re-stamp, not a real state change.
+
+> 2026.7+ primes `options.for` duration tracking for purpose-specific **conditions** from recorded
+> history, so those don't restart from zero on creation/reload. The resets described here still
+> apply to trigger `for:` clauses and to `last_changed`-based template math.
+
+### Time Trigger
+
+Fires at specific times.
+
+```yaml
+# Fixed time
+triggers:
+  - trigger: time
+    at: "07:00:00"
+
+# Input datetime helper
+triggers:
+  - trigger: time
+    at: input_datetime.morning_alarm
+
+# Time pattern (every 5 minutes)
+triggers:
+  - trigger: time_pattern
+    minutes: "/5"
+
+# Every hour at :30
+triggers:
+  - trigger: time_pattern
+    minutes: 30
+```
+
+### Sun Trigger
+
+Fires at sunrise/sunset with optional offset.
+
+```yaml
+triggers:
+  - trigger: sun
+    event: sunset
+    offset: "-00:30:00"  # 30 minutes before sunset
+```
+
+### Event Trigger
+
+Fires on Home Assistant events.
+
+```yaml
+# ZHA button event
+triggers:
+  - trigger: event
+    event_type: zha_event
+    event_data:
+      device_ieee: "00:11:22:33:44:55:66:77"
+      command: "on"
+
+# Custom event
+triggers:
+  - trigger: event
+    event_type: my_custom_event
+```
+
+**Multi-trigger guard for `trigger.event`:** In automations mixing event and non-event triggers, `trigger.event` is `LoggingUndefined` for non-event triggers. Attribute access (`.data`, `.split()`) raises `UndefinedError`; `in` on a bare `LoggingUndefined` silently returns `False`. Use `trigger.platform == 'event'` as a short-circuit guard:
+
+```yaml
+# AVOID — trigger.event.data raises UndefinedError when a non-event trigger fires
+conditions:
+  - "{{ 'light.kitchen' in trigger.event.data.entity_id }}"
+
+# CORRECT — guard prevents evaluating trigger.event on non-event triggers
+conditions:
+  - "{{ trigger.platform == 'event' and 'light.kitchen' in trigger.event.data.entity_id }}"
+```
+
+**Firing an event** (the action counterpart of this trigger) — useful for decoupling automations (one fires `my_event`, several others trigger on it):
+
+```yaml
+actions:
+  - event: my_custom_event
+    event_data:
+      source: kitchen
+      value: "{{ states('sensor.power') }}"   # templates work directly; event_data_template is no longer needed
+```
+
+### MQTT Trigger
+
+Fires on MQTT messages.
+
+```yaml
+triggers:
+  - trigger: mqtt
+    topic: "zigbee2mqtt/button/action"
+    payload: "single"
+```
+
+### Device Trigger (Use Sparingly)
+
+Device triggers key off an opaque `device_id` rather than a readable `entity_id`. Prefer entity-based `state` triggers where practical — they're self-documenting and easier to maintain.
+
+```yaml
+# Prefer a state trigger on a readable entity_id where practical
+triggers:
+  - trigger: device
+    domain: mqtt
+    device_id: abc123
+    type: action
+    subtype: single
+```
+
+A matching **`condition: device`** variant exists (`device_id`, `domain`, `entity_id`, `type`) with the same trade-off — prefer a `state`/`numeric_state` condition on a readable `entity_id` where practical.
+
+### Zone Trigger
+
+Fires when a person or device tracker enters or leaves a zone.
+
+```yaml
+triggers:
+  - trigger: zone
+    entity_id: person.john
+    zone: zone.home
+    event: enter   # "enter" or "leave"
+```
+
+To *check* zone membership in a condition rather than trigger on the transition, see [Zone Condition](#zone-condition).
+
+### Native Zone Triggers & Conditions (2026.6+)
+
+2026.6 added native, **any-zone** zone primitives (not just home); with the rest of the purpose-specific family they became default (non-Labs) in 2026.7. They serialize as the standard `<domain>.<name>` shape with `options:` and `target:` blocks:
+
+- **Triggers:** `zone.entered`, `zone.left`, `zone.occupancy_detected`, `zone.occupancy_cleared`
+- **Conditions:** `zone.in_zone`, `zone.not_in_zone`, `zone.occupancy_is_detected`, `zone.occupancy_is_not_detected`
+
+```yaml
+# Trigger — fires when a tracked person/device enters a zone
+triggers:
+  - trigger: zone.entered
+    target:
+      entity_id: person.john      # person or device_tracker
+    options:
+      zone: zone.office
+      behavior: each              # "each" (default), "all", or "first"
+      # for: "00:05:00"           # optional dwell time
+```
+
+Triggers take `behavior: each` (default), `all`, or `first`; the matching **conditions** use a *different* enum — `behavior: any` (default) or `all` (see [Purpose-Specific Triggers & Conditions](#purpose-specific-triggers--conditions-default-since-20267)). The classic flat [Zone Trigger](#zone-trigger) / [Zone Condition](#zone-condition) and plain `state` triggers remain supported.
+
+> The `entered_home`/`left_home`/`is_home`/`is_not_home` device automations were removed in **2026.5** (see [below](#presence-and-person-triggers-and-conditions-removed-in-20265)) — 2026.6 only *adds* these any-zone primitives as the native successor.
+
+### Template Trigger
+
+Fires when a Jinja template renders truthy. Prefer `state`/`numeric_state` whenever the change can be expressed natively — reach for the template trigger only for cross-entity or derived conditions.
+
+```yaml
+triggers:
+  - trigger: template
+    value_template: "{{ states('sensor.temp') | float > 25 and is_state('binary_sensor.window', 'on') }}"
+    for: "00:05:00"   # optional: template must stay true this long before firing
+```
+
+### Calendar Trigger
+
+Fires at the start or end of a calendar event, with an optional offset. Prefer this over a `state` trigger on the calendar entity, which only tracks one event at a time.
+
+```yaml
+triggers:
+  - trigger: calendar
+    entity_id: calendar.work
+    event: start          # "start" or "end"
+    offset: "-00:15:00"   # optional: fire 15 min before the event
+```
+
+Exposes `trigger.calendar_event` with `.summary`, `.start`, `.end`, `.description`, `.location` for filtering by event details.
+
+### Webhook Trigger
+
+Fires when an HTTP request hits `/api/webhook/<webhook_id>`. The canonical way to trigger HA from external systems (scripts, IFTTT, other servers).
+
+```yaml
+triggers:
+  - trigger: webhook
+    webhook_id: "my-secret-hook-id"
+    allowed_methods: [POST, PUT]   # optional; default POST + PUT
+    local_only: true               # optional; default true — set false for external callers
+```
+
+Read the payload via `trigger.json`, `trigger.data` (form-encoded), `trigger.query`, or `trigger.headers`.
+
+### Home Assistant Trigger
+
+Fires when HA finishes starting or begins shutting down.
+
+```yaml
+triggers:
+  - trigger: homeassistant
+    event: start   # "start" or "shutdown"
+```
+
+Use `start` for boot-time setup (restore state, resync devices). `shutdown` handlers get only ~20 seconds before HA stops — keep them short.
+
+> **Don't recompute a user-settable value on `start`.** A boot-time recompute (e.g. re-deriving a
+> mode from sensors) overwrites any manual override on every restart. For user-settable state, let
+> the helper restore its value (omit `initial:` — see `helper-selection.md`) and only *re-sync
+> dependent flags* from the restored value on start.
+
+### Conversation Trigger
+
+Fires when a voice/Assist sentence matches. The match syntax supports `[optional]` words, `(a|b)` alternatives, and `{slot}` wildcards.
+
+```yaml
+triggers:
+  - trigger: conversation
+    command:
+      - "party time"
+      - "play {album} by {artist}"
+```
+
+Captured wildcards are available as `trigger.slots.<name>`; the full text is `trigger.sentence`. To make the assistant speak a dynamic reply, use the `set_conversation_response` action (`- set_conversation_response: "Done"`; `~` clears a previously set response).
+
+### Tag Trigger
+
+Fires when an NFC/QR tag is scanned.
+
+```yaml
+triggers:
+  - trigger: tag
+    tag_id: "A7-6B-90-5F"
+    device_id: 0e19cd3c...   # optional: limit to one specific scanner device
+```
+
+### Geolocation Trigger
+
+Fires when a transient entity from a geolocation feed (NWS alerts, GDACS, fire-service feeds, USGS quakes) enters or leaves a zone. Keyed by the feed `source`, not a fixed `entity_id`.
+
+```yaml
+triggers:
+  - trigger: geo_location
+    source: nsw_rural_fire_service_feed
+    zone: zone.fire_alert
+    event: enter   # "enter" or "leave"
+```
+
+### Persistent Notification Trigger
+
+Fires on persistent-notification lifecycle changes (e.g. react to an integration posting an error notice).
+
+```yaml
+triggers:
+  - trigger: persistent_notification
+    update_type: [added, removed]     # any of: added, removed, updated, current; omit for all
+    notification_id: invalid_config   # optional: filter to one notification
+```
+
+### Presence and Person Triggers and Conditions (Removed in 2026.5)
+
+The `entered_home`/`left_home` device trigger types and `is_home`/`is_not_home` device condition types for `person` and `device_tracker` domains were **removed in 2026.5**. Use state triggers and conditions instead.
+
+```yaml
+# AVOID (removed in 2026.5)
+triggers:
+  - trigger: device
+    domain: person
+    type: entered_home
+    entity_id: person.john
+
+# CORRECT — state trigger
+triggers:
+  - trigger: state
+    entity_id: person.john
+    to: "home"
+
+# CORRECT — state condition
+condition: state
+entity_id: person.john
+state: "home"
+```
+
+2026.7 presence semantics to keep in mind:
+
+- A person located by a home presence scanner (router/Bluetooth) may report **no latitude/longitude** — don't read coordinates to infer home presence; use the state or the `in_zones` attribute.
+- Person and device_tracker entities expose `in_zones` (all zones containing them, smallest first). Zone entity states (person counts) are derived from it, so a person counts in **every** overlapping zone they're inside, not just one.
+- A position-aware device_tracker's state is the **smallest** containing zone (previously: the zone whose center is closest).
+
+For non-home zone presence, prefer the native zone family (see [Native Zone Triggers & Conditions](#native-zone-triggers--conditions-20266)) or `#zone-condition`.
+
+### Timer Entity Triggers (2026.5+)
+
+Timer lifecycle events are purpose-specific triggers: `timer.started`, `timer.finished`, `timer.paused`, `timer.restarted`, `timer.cancelled`, plus `timer.remaining_time_reached` (renamed from `timer.time_remaining` in 2026.7), which fires at a set remaining time.
+
+```yaml
+triggers:
+  - trigger: timer.remaining_time_reached
+    target:
+      entity_id: timer.cooking
+    options:
+      remaining: "00:05:00"
+```
+
+The legacy `event`-trigger form (`event_type: timer.finished` with `event_data: {entity_id: ...}`) still works, but the purpose-specific form supports targets and is preferred.
+
+### Media Player Triggers/Conditions (2026.5+)
+
+Media players have purpose-specific triggers (`media_player.started_playing`, `media_player.paused_playing`, `media_player.stopped_playing`, `media_player.turned_on`, `media_player.turned_off`, `media_player.muted`, `media_player.unmuted`, `media_player.volume_changed`, `media_player.volume_crossed_threshold`) and matching conditions (`media_player.is_playing`, `media_player.is_paused`, `media_player.is_not_playing`, `media_player.is_on`, `media_player.is_off`, `media_player.is_muted`, `media_player.is_unmuted`, `media_player.is_volume`).
+
+```yaml
+triggers:
+  - trigger: media_player.started_playing
+    target:
+      entity_id: media_player.living_room
+    options:
+      for: "00:00:30"   # optional: playback must continue this long
+```
+
+The generic forms still apply where no purpose-specific block fits (e.g. `state` with `to: "idle"`, or `numeric_state` on `attribute: volume_level`).
+
+---
+
+## Wait Actions
+
+### wait_for_trigger (Preferred)
+
+Event-driven wait. More efficient than polling.
+
+```yaml
+# Wait for door to close
+- wait_for_trigger:
+    - trigger: state
+      entity_id: binary_sensor.door
+      to: "off"
+  timeout:
+    minutes: 5
+  continue_on_timeout: false  # Stop automation if timeout
+
+# Wait for any of multiple triggers
+- wait_for_trigger:
+    - trigger: state
+      entity_id: binary_sensor.door
+      to: "off"
+    - trigger: event
+      event_type: mobile_app_notification_action
+      event_data:
+        action: "CLOSE_DOOR"
+```
+
+### wait_template (Use Sparingly)
+
+Polls until template is true. **Immediately continues if already true.**
+
+```yaml
+# Only use when wait_for_trigger cannot express the condition
+- wait_template: "{{ states('sensor.temperature') | float > 25 }}"
+  timeout:
+    minutes: 10
+```
+
+**Key difference:**
+- `wait_for_trigger` waits for a **change** to occur
+- `wait_template` waits for a **condition** to be true (passes immediately if already true)
+
+### Checking Wait Results
+
+Both waits set `wait.completed` and `wait.remaining`:
+
+```yaml
+- wait_for_trigger:
+    - trigger: state
+      entity_id: binary_sensor.door
+      to: "off"
+  timeout:
+    minutes: 5
+
+- if:
+    - "{{ not wait.completed }}"
+  then:
+    - action: notify.mobile_app
+      data:
+        message: "Door still open after 5 minutes!"
+```
+
+### delay
+
+Pauses the sequence for a fixed time. Accepts a time string, a units dict, or a template. Prefer `wait_for_trigger` when waiting for an *event* rather than a fixed duration.
+
+```yaml
+- delay: "00:01:30"                 # HH:MM:SS
+- delay: {minutes: 1, seconds: 30}  # units dict (combinable)
+- delay: "{{ states('input_number.delay_seconds') | int }}"   # template → seconds
+```
+
+---
+
+## Automation Modes
+
+The `mode` determines what happens when an automation triggers while already running.
+
+### single (Default)
+
+New triggers are ignored while running. A warning is logged.
+
+**Best for:** One-shot notifications, actions that shouldn't overlap.
+
+```yaml
+automation:
+  - alias: "Doorbell notification"
+    mode: single
+    triggers:
+      - trigger: state
+        entity_id: binary_sensor.doorbell
+        to: "on"
+    actions:
+      - action: notify.mobile_app
+        data:
+          message: "Someone at the door!"
+```
+
+### restart
+
+Stops the current run and starts fresh. Timer-based actions are reset.
+
+**Best for:** Motion-activated lights with timeout, retriggerable delays.
+
+```yaml
+mode: restart  # Re-trigger resets the timer
+```
+
+See `references/examples.yaml` Example 1 for a complete motion-light automation using restart + wait_for_trigger.
+
+### queued
+
+Queues new triggers to run after current run completes.
+
+**Best for:** Sequential actions, door locks, garage doors.
+
+```yaml
+automation:
+  - alias: "Garage door controller"
+    mode: queued
+    max: 5  # Maximum queue size
+    triggers:
+      - trigger: state
+        entity_id: input_boolean.garage_door_trigger
+        to: "on"
+    actions:
+      - action: cover.toggle
+        target:
+          entity_id: cover.garage_door
+      - delay:
+          seconds: 20  # Wait for door to fully open/close
+```
+
+### parallel
+
+Runs multiple instances simultaneously.
+
+**Best for:** Per-entity actions with `trigger.entity_id`, notifications that shouldn't block.
+
+```yaml
+automation:
+  - alias: "Window open too long"
+    mode: parallel
+    max: 10  # Maximum parallel runs
+    triggers:
+      - trigger: state
+        entity_id:
+          - binary_sensor.window_bedroom
+          - binary_sensor.window_kitchen
+          - binary_sensor.window_living
+        to: "on"
+        for:
+          minutes: 30
+    actions:
+      - action: notify.mobile_app
+        data:
+          message: "{{ trigger.to_state.name }} has been open for 30 minutes"
+```
+
+### max_exceeded
+
+Control logging when max runs are exceeded:
+
+```yaml
+automation:
+  - alias: "Quiet automation"
+    mode: single
+    max_exceeded: silent  # No warning logged
+```
+
+---
+
+## Continue on Error
+
+Any automation action can be set to continue execution even if it fails, using the `continue_on_error` key. Since 2026.3, this is also configurable in the visual editor (three-dots menu on any action).
+
+```yaml
+actions:
+  - action: light.turn_on
+    target:
+      entity_id: light.patio
+    continue_on_error: true  # Automation proceeds even if this fails
+  - action: notify.mobile_app
+    data:
+      message: "Light action attempted"
+```
+
+**Use sparingly** — silently swallowing errors makes debugging harder. Best for non-critical actions (e.g., logging, optional notifications) where a failure shouldn't block the rest of the automation.
+
+---
+
+## Stopping a Sequence
+
+`stop:` halts the rest of the sequence cleanly — clearer than nesting everything inside a `choose`/`if` guard.
+
+```yaml
+- stop: "reason shown in the trace"
+
+# Mark the run as failed (red in the trace, propagates to callers):
+- stop: "unexpected state"
+  error: true
+
+# Return a value from a script and halt:
+- stop: "done"
+  response_variable: my_result
+```
+
+---
+
+## Variables
+
+Compute a value once and reuse it — keeps sequences DRY and avoids repeating long templates.
+
+```yaml
+# Mid-sequence (scoped to the remaining steps of this run):
+- variables:
+    brightness: 100
+    targets:
+      - light.kitchen
+      - light.living_room
+
+# Automation/script top level (full templates; usable in conditions and actions):
+variables:
+  threshold: 25
+```
+
+`trigger_variables:` is a separate top-level key evaluated **before** triggers fire — it supports **limited templates only** (no `states()`/`state_attr()`), mainly for passing a blueprint `!input` into trigger options. Don't put state-based templates there.
+
+---
+
+## Capturing Action Responses
+
+`response_variable` captures the data a service returns (e.g. `weather.get_forecasts`, `calendar.get_events`, `todo.get_items`) into a variable for later steps — the only native mechanism for response-aware service calls.
+
+```yaml
+- action: weather.get_forecasts
+  target:
+    entity_id: weather.home
+  data:
+    type: daily
+  response_variable: forecast
+- action: notify.mobile_app
+  data:
+    message: "High today: {{ forecast['weather.home'].forecast[0].temperature }}°"
+```
+
+---
+
+## Repeat Actions
+
+Four repeat variants are available:
+
+```yaml
+# Repeat N times
+- repeat:
+    count: 3
+    sequence:
+      - action: light.toggle
+        target:
+          entity_id: light.bedroom
+
+# Repeat while condition is true
+- repeat:
+    while:
+      - condition: state
+        entity_id: binary_sensor.door
+        state: "on"
+    sequence:
+      - action: notify.mobile_app
+        data:
+          message: "Door still open"
+      - delay:
+          minutes: 5
+
+# Repeat until condition is true
+- repeat:
+    until:
+      - condition: numeric_state
+        entity_id: sensor.temperature
+        below: 25
+    sequence:
+      - delay:
+          minutes: 1
+
+# Repeat for each item in a list
+- repeat:
+    for_each:
+      - "light.kitchen"
+      - "light.bedroom"
+      - "light.hallway"
+    sequence:
+      - action: light.turn_off
+        target:
+          entity_id: "{{ repeat.item }}"
+```
+
+Access `repeat.index` (1-based) and `repeat.item` (for `for_each`) inside the sequence.
+
+---
+
+## if/then vs choose
+
+### if/then/else
+
+Use for simple binary conditions:
+
+```yaml
+actions:
+  - if:
+      - condition: state
+        entity_id: sun.sun
+        state: "below_horizon"
+    then:
+      - action: light.turn_on
+        target:
+          entity_id: light.porch
+    else:
+      - action: light.turn_off
+        target:
+          entity_id: light.porch
+```
+
+### choose
+
+Use for multiple branches (like switch/case):
+
+```yaml
+actions:
+  - choose:
+      - conditions:
+          - condition: trigger
+            id: "morning"
+        sequence:
+          - action: scene.turn_on
+            target:
+              entity_id: scene.morning
+
+      - conditions:
+          - condition: trigger
+            id: "evening"
+        sequence:
+          - action: scene.turn_on
+            target:
+              entity_id: scene.evening
+
+    default:
+      - action: light.turn_off
+        target:
+          area_id: living_room
+```
+
+---
+
+## Parallel Actions
+
+The `parallel:` action runs a group of actions **concurrently** within one sequence. This is distinct from `mode: parallel` (see [Automation Modes](#automation-modes)), which controls concurrency of whole automation *runs*. Steps inside a nested `sequence:` still run in order.
+
+```yaml
+actions:
+  - parallel:
+      - action: notify.person1
+        data:
+          message: "Sent at the same time"
+      - sequence:
+          - wait_for_trigger:
+              - trigger: state
+                entity_id: binary_sensor.motion
+                to: "on"
+          - action: notify.person2
+```
+
+---
+
+## Trigger IDs
+
+Assign IDs to triggers for use in conditions and choose:
+
+```yaml
+automation:
+  - alias: "Multi-trigger automation"
+    triggers:
+      - trigger: state
+        entity_id: binary_sensor.motion
+        to: "on"
+        id: "motion_on"
+
+      - trigger: state
+        entity_id: binary_sensor.motion
+        to: "off"
+        for:
+          minutes: 5
+        id: "motion_off"
+
+    actions:
+      - choose:
+          - conditions:
+              - condition: trigger
+                id: "motion_on"
+            sequence:
+              - action: light.turn_on
+                target:
+                  entity_id: light.hallway
+
+          - conditions:
+              - condition: trigger
+                id: "motion_off"
+            sequence:
+              - action: light.turn_off
+                target:
+                  entity_id: light.hallway
+```
+
+Access trigger info in templates with `trigger.id`, `trigger.entity_id`, `trigger.to_state`, etc.
+
+---
+
+## Documenting Automations & Scripts
+
+Two fields document *intent* (the why, not the what):
+
+- **`description:`** — a top-level automation/script field for the overall purpose.
+- **`note:`** (2026.6) — a per-block annotation on any individual trigger, condition, or action (including `wait_*`, `choose` branches, `if`/`then`/`else`, `parallel`, `repeat`, and nested `sequence` steps). Scripts have no triggers, so notes there apply to sequence steps and conditions only. The YAML key is the **singular `note:`** (not `notes:`) — the editor surfaces it as a "Notes" field, but the docs never show the key string, so don't guess the plural.
+
+```yaml
+description: "Turn on the porch light at dusk; skip if already on."
+triggers:
+  - trigger: sun
+    event: sunset
+    note: "Dusk, not full dark — sunset event is ~civil twilight."
+actions:
+  - action: light.turn_on
+    target:
+      entity_id: light.porch
+    note: "Brightness intentionally left at last value."
+```
+
+`note:` is **stored documentation only** — it persists in the saved/edited config but is stripped from the running automation object at runtime, so don't rely on reading it back. Keep notes concise (intent, assumptions, why a threshold/mode/entity was chosen).
+
+---
+
+## Disabling Automations
+
+Home Assistant provides two distinct ways to disable an automation, with different persistence and behavior.
+
+### Method 1: Turn Off (Temporary, State Machine)
+
+`automation.turn_off` disables the automation's configured triggers — it will not fire automatically. The entity remains in the state machine with state `off` and can still be invoked via the `automation.trigger` service.
+
+```yaml
+- action: automation.turn_off
+  target:
+    entity_id: automation.my_automation
+  data:
+    stop_actions: true  # default: true — stops currently running actions
+```
+
+| Attribute | Value |
+| --- | --- |
+| `stop_actions` | Optional. Stops currently active action runs. **Defaults to `true`.** |
+| Survives reload? | Yes — state is stored in `core.restore_state` |
+| Survives restart? | Only if the automation has an `id:` field — `core.restore_state` matches by `entity_id`, which is derived from `alias:` without `id:` and is unstable if automations are added, removed, or have conflicting aliases |
+| Entity in state machine? | Yes — state is `off` |
+| Re-enable via | `automation.turn_on` |
+
+**`initial_state` override:** If the automation YAML contains an explicit `initial_state` value, it overrides the stored state after a restart (`true` forces on, `false` forces off regardless of stored state).
+
+### Method 2: Registry Disable (Permanent, via Entity Registry)
+
+Disabling an automation via *Settings → Automations → open automation → ⋮ → Settings → Enabled toggle* sets `disabled_by: user` in `core.entity_registry`. The entity is removed from the state machine entirely.
+
+| Attribute | Value |
+| --- | --- |
+| Survives reload? | Yes — stored in `core.entity_registry` |
+| Survives restart? | Yes |
+| Entity in state machine? | **No** — `GET /api/states/<entity_id>` returns 404 |
+| Requires `id:` field? | Yes — the `id:` field in `automations.yaml` becomes the automation's `unique_id`, which is required for an entity registry entry |
+| Re-enable via | UI toggle (*Settings → Automations → open automation → ⋮ → Settings → Enabled toggle*) or WebSocket API (`config/entity_registry/update` with `{"disabled_by": null}`) |
+
+**Note:** The list toggle on the Automations page (`/config/automation/dashboard`) calls `automation.turn_on`/`turn_off` (Method 1). The *Enabled toggle* under *Settings → Automations → open automation → ⋮ → Settings → Enabled toggle* modifies the entity registry (Method 2). Both can be active simultaneously — an automation can be registry-enabled but in state `off`, or registry-disabled but with a stored `on` state.
+
+### AVOID: `enabled: false` in automations.yaml
+
+```yaml
+# AVOID — enabled: is not a valid top-level key
+- alias: My Automation
+  enabled: false       # not a valid top-level key
+  triggers: ...
+```
+
+`enabled:` is **not** a valid top-level key in `automations.yaml`. Home Assistant rejects unknown keys during schema validation, so the automation loads as `unavailable`.
+
+```yaml
+# CORRECT — disable temporarily via service (Method 1)
+- action: automation.turn_off
+  target:
+    entity_id: automation.my_automation
+
+# CORRECT — disable permanently via entity registry (Method 2)
+# UI: Settings → Automations → open automation → ⋮ → Settings → Enabled toggle
+# Or via WebSocket API: config/entity_registry/update (disabled_by: user)
+```
+
+### `enabled:` on individual triggers, conditions, and actions
+
+While `enabled:` is not valid as a *top-level* automation key (above), it **is** valid on any individual trigger, condition, or action — as a boolean or a blueprint `!input`. A disabled element is skipped without disabling the whole automation. It also accepts a **limited template** (variables / blueprint inputs only — no `states()`), evaluated **once when the automation loads**.
+
+```yaml
+triggers:
+  - trigger: sun
+    event: sunset
+    enabled: false                       # statically disabled
+  - trigger: time
+    at: "15:30:00"
+    enabled: "{{ enable_afternoon }}"    # limited template over a variable/!input; evaluated once at load
+actions:
+  - action: notify.notify
+    enabled: false
+```

--- a/.claude/skills/home-assistant-best-practices/references/blueprint-guide.md
+++ b/.claude/skills/home-assistant-best-practices/references/blueprint-guide.md
@@ -1,0 +1,271 @@
+# Blueprints
+
+A **blueprint is a reusable, parameterized automation/script/template** — a skeleton whose device- and entity-specific parts are replaced by user-provided **inputs**. Author a blueprint only when a pattern will be instantiated more than once or shared/distributed. A one-off automation should stay a plain automation; don't blueprint what you'll use once.
+
+## Table of Contents
+1. [When to Author a Blueprint](#when-to-author-a-blueprint)
+2. [Blueprint Metadata](#blueprint-metadata)
+3. [Inputs and Selectors](#inputs-and-selectors)
+4. [`target` Selector vs `entity` Selector](#target-selector-vs-entity-selector)
+5. [Defaults](#defaults)
+6. [Input Sections](#input-sections)
+7. [Referencing Inputs (`!input`) and Templating](#referencing-inputs-input-and-templating)
+8. [Versioning and Updates](#versioning-and-updates)
+9. [Annotated Example](#annotated-example)
+10. [Common Pitfalls](#common-pitfalls)
+
+---
+
+## When to Author a Blueprint
+
+| Signal | Blueprint? |
+|--------|-----------|
+| Same logic wanted for several sensors/rooms/devices | Yes — parameterize the varying parts as inputs |
+| Sharing/distributing to other users | Yes — a blueprint imports cleanly via `source_url` |
+| A single automation for one specific set of entities | No — write a normal automation |
+| Logic differs meaningfully per instance | No — a blueprint that needs many conditional inputs is usually two blueprints |
+
+Blueprints exist for three domains, set by the `domain:` key: `automation`, `script`, and `template`. The input/selector rules below apply to all three; the surrounding body (`triggers`/`actions` vs `sequence` vs `sensor`/`binary_sensor`) is whatever that domain normally uses.
+
+## Blueprint Metadata
+
+Every blueprint opens with a `blueprint:` mapping:
+
+```yaml
+blueprint:
+  name: Motion-Activated Light          # required; short and descriptive
+  description: Turn a light on when motion is detected, off after a delay.
+  domain: automation                    # required: automation | script | template
+  author: Your Name                     # optional
+  source_url: https://github.com/you/ha-blueprints/blob/main/motion_light.yaml
+  homeassistant:
+    min_version: "2024.10.0"           # optional; gate version-specific features (see note below)
+  input:
+    # ... see below
+```
+
+- **`source_url`** — the canonical URL of the blueprint file. Always set it. It enables **"Re-import blueprint"** (in-place updates when you publish a fix), provides attribution, and is what the *Import Blueprint* dialog stores. A blueprint without `source_url` can't be updated from source and is awkward to share.
+- **`min_version`** — set it when the blueprint uses a feature added in a specific release (e.g. input sections need `2024.6.0`; the in-item `action:` key replacing `service:` needs `2024.8.0`; the plural `triggers:`/`conditions:`/`actions:` keys and the in-item `trigger:` key replacing `platform:` need `2024.10.0`). HA refuses to import the blueprint on older versions instead of failing mysteriously at runtime.
+- **`domain`** must match the body: an `automation` blueprint has `triggers:`/`actions:`, a `script` blueprint has a `sequence:`, a `template` blueprint defines template entities.
+
+## Inputs and Selectors
+
+Every entity, device, area, number, or option a user should customize is an **input** with a **selector**. The selector determines the UI control and, critically, *validates and constrains* what the user can pick.
+
+**Prefer a typed selector over free text.** A `text` selector for an entity forces users to type `light.living_room` correctly by hand — a typo passes validation and fails silently at runtime. An `entity` selector gives a filtered picker that can only yield valid, existing entities.
+
+Common selectors:
+
+| Selector | Yields | Use for |
+|----------|--------|---------|
+| `entity` | entity_id(s) | Picking specific entities; filter with `domain`, `device_class`, `integration` |
+| `target` | a target dict (entities/devices/areas/floors/labels) | Anything you pass straight to a service call's `target:` |
+| `device` | device_id(s) | Device triggers, or device-level actions (rare — prefer entities) |
+| `area` / `floor` / `label` | area/floor/label id(s) | Scoping actions to a whole area/floor/label |
+| `number` | number | Timeouts, brightness, thresholds; set `min`/`max`/`step`/`mode`/`unit_of_measurement` |
+| `boolean` | true/false | On/off toggles |
+| `select` | a chosen option | A fixed list of choices (`options:`) |
+| `time` / `duration` | time / duration | Schedules and delays |
+| `action` | a sequence of actions | Letting the user inject their own actions (e.g. "what to do when triggered") |
+| `text` | free string | Genuinely free text only (messages, names) — never entity IDs |
+| `object` | arbitrary YAML | Advanced structured input; last resort |
+
+Constrain entity/device selectors so users can only pick valid targets:
+
+```yaml
+motion_sensor:
+  name: Motion sensor
+  selector:
+    entity:
+      domain: binary_sensor
+      device_class: motion      # only motion binary_sensors are offered
+```
+
+Add `multiple: true` to accept a list. Filter by `integration:` when the blueprint is integration-specific.
+
+## `target` Selector vs `entity` Selector
+
+The issue this guide most often resolves. Both point at "what to control," but they produce different shapes:
+
+- **`entity` selector → `entity_id`(s).** Use it when you need the id itself — for a `state` trigger's `entity_id`, a `states(...)` lookup in a template, or an action that specifically wants an entity.
+- **`target` selector → a target dict** (`{entity_id, device_id, area_id, floor_id, label_id}`). Use it when the value flows straight into a service call's `target:`. It lets the user target entities, whole devices, or entire areas/floors/labels — more flexible for "act on these lights," where the user might prefer to say "all lights in the living room area."
+
+```yaml
+# target selector — pass directly to target:
+target_light:
+  selector:
+    target:
+      entity:
+        domain: light
+# ...
+actions:
+  - action: light.turn_on
+    target: !input target_light        # accepts entity/device/area
+
+# entity selector — you need the id for a trigger / template
+motion_sensor:
+  selector:
+    entity:
+      domain: binary_sensor
+# ...
+triggers:
+  - trigger: state
+    entity_id: !input motion_sensor    # needs a concrete entity_id
+```
+
+Rule of thumb: **controlling things → `target`; observing/templating a specific entity → `entity`.**
+
+## Defaults
+
+Provide `default:` for tuning inputs so the blueprint works out of the box:
+
+```yaml
+no_motion_wait:
+  name: Wait time
+  default: 120                          # sensible default → user can skip it
+  selector:
+    number: { min: 0, max: 3600, unit_of_measurement: seconds, mode: slider }
+```
+
+**Don't** default entity/device/target selectors — there's no universally-correct entity, so the user must choose. An input with no `default:` is required; an input with a `default:` is optional. Use this deliberately: required for the entities the blueprint acts on, optional (defaulted) for behavior tuning.
+
+## Input Sections
+
+Blueprints with many inputs become a wall of fields. Group them with sections (HA `2024.6.0`+). A section is an input entry that itself contains an `input:` map:
+
+```yaml
+input:
+  devices:
+    name: Devices
+    icon: mdi:motion-sensor
+    input:                              # nested inputs belong to this section
+      motion_sensor: { name: Motion sensor, selector: { entity: { domain: binary_sensor, device_class: motion } } }
+      target_light:  { name: Light(s),      selector: { target: { entity: { domain: light } } } }
+  settings:
+    name: Settings
+    icon: mdi:cog
+    collapsed: true                     # collapsed by default — advanced knobs out of the way
+    input:
+      no_motion_wait: { name: Wait time, default: 120, selector: { number: { min: 0, max: 3600 } } }
+```
+
+`!input` still references inputs by their own key (`!input motion_sensor`), regardless of which section they live in — section names are for display only.
+
+## Referencing Inputs (`!input`) and Templating
+
+Inside the blueprint body, reference an input with the `!input` YAML tag: `entity_id: !input motion_sensor`.
+
+**The #1 blueprint bug:** `!input` is a YAML tag, **not** a template value — you cannot write `{{ !input x }}` or drop `!input` inside a Jinja expression. To use an input in a template, first expose it as a **variable**, then reference the variable:
+
+```yaml
+variables:
+  brightness_pct: !input brightness     # bind input → variable at script level
+# ...
+actions:
+  - action: light.turn_on
+    target: !input target_light
+    data:
+      brightness_pct: "{{ brightness_pct }}"   # use the variable, never !input
+```
+
+For **templated triggers**, bind inputs through `trigger_variables:` (a separate top-level key evaluated before triggers fire). It supports **limited templates only** — no `states()`/`state_attr()` — and exists mainly to pass a blueprint `!input` into trigger options (see `automation-patterns.md#trigger-types`). Don't put state-based templates there.
+
+`enabled:` on an individual trigger/condition/action also accepts a blueprint `!input` (evaluated once at load) — handy for optional behavior toggled by a `boolean` input (see `automation-patterns.md#enabled-on-individual-triggers-conditions-and-actions`).
+
+## Versioning and Updates
+
+Users import a blueprint once, then create automations from it. When you publish changes:
+
+- **Renaming or removing an input key breaks every existing instance** — their stored `!input` references no longer resolve. Treat input keys as a public API.
+- **Add** new inputs rather than changing old ones, and give every new input a `default:` so existing automations keep working after a re-import without the user touching them.
+- Bump `min_version` if a change relies on a newer HA feature.
+- Keep `source_url` stable — it's the update anchor. Users re-import from the same URL to pick up fixes.
+
+## Annotated Example
+
+A complete motion-light automation blueprint demonstrating every practice above:
+
+```yaml
+blueprint:
+  name: Motion-Activated Light
+  description: Turn a light (or area) on when motion is detected, off after a delay.
+  domain: automation
+  author: Your Name
+  source_url: https://github.com/you/ha-blueprints/blob/main/motion_light.yaml
+  homeassistant:
+    min_version: "2024.10.0"                # modern triggers/actions syntax (input sections alone need only 2024.6.0)
+  input:
+    devices:
+      name: Devices
+      icon: mdi:motion-sensor
+      input:
+        motion_sensor:
+          name: Motion sensor
+          selector:
+            entity:
+              domain: binary_sensor
+              device_class: motion          # constrained picker — no free text
+        target_light:
+          name: Light(s) to control
+          selector:
+            target:                          # target → user may pick lights OR an area
+              entity:
+                domain: light
+    settings:
+      name: Settings
+      icon: mdi:cog
+      collapsed: true
+      input:
+        no_motion_wait:
+          name: Wait time
+          description: Seconds to keep the light on after the last motion.
+          default: 120                       # sensible default → optional input
+          selector:
+            number: { min: 0, max: 3600, unit_of_measurement: seconds, mode: slider }
+        brightness:
+          name: Brightness
+          default: 100
+          selector:
+            number: { min: 1, max: 100, unit_of_measurement: "%" }
+
+# Body — device-specific values come only from !input, never hardcoded:
+mode: restart                                # re-trigger resets the timer
+max_exceeded: silent
+
+variables:
+  brightness_pct: !input brightness          # expose input for use in a template
+
+triggers:
+  - trigger: state
+    entity_id: !input motion_sensor          # entity selector → concrete entity_id
+    to: "on"
+
+actions:
+  - action: light.turn_on
+    target: !input target_light              # target selector → passed straight to target:
+    data:
+      brightness_pct: "{{ brightness_pct }}" # variable, not !input, inside the template
+  - wait_for_trigger:
+      - trigger: state
+        entity_id: !input motion_sensor
+        to: "off"
+  - delay:
+      seconds: !input no_motion_wait
+  - action: light.turn_off
+    target: !input target_light
+```
+
+## Common Pitfalls
+
+| Pitfall | Do instead | Why |
+|---------|-----------|-----|
+| Free-text field for an entity/device | `entity` / `target` / `device` selector | Typed selectors validate the choice; a typo in text fails silently at runtime |
+| Hardcoded `light.living_room` in the body | `!input` with a selector | Hardcoding defeats the entire purpose of a blueprint — it can't be reused |
+| `!input` used directly in a template (`{{ !input x }}`) | Bind to a `variables:` entry, use the variable | `!input` is a YAML tag, not a template value — the template errors or ignores it |
+| State-based template in `trigger_variables:` | Move logic into a template condition/trigger | `trigger_variables` allows limited templates only (no `states()`) |
+| No `source_url` | Set it to the file's canonical URL | Enables in-place re-import/updates and sharing |
+| No `default:` on tuning inputs | Add a sensible `default:` | Makes the input optional and the blueprint usable out of the box |
+| `default:` on the entity the blueprint controls | Leave it required (no default) | There's no universally-correct entity; the user must choose |
+| `entity` selector where you pass to `target:` | Use a `target` selector | `target` lets users pick areas/devices too and drops straight into `target:` |
+| Renaming/removing input keys in an update | Add new inputs (with defaults); keep old keys | Existing automations reference keys by name and break on rename |
+| Missing `min_version` for a used feature | Set `homeassistant.min_version` | HA blocks import on old versions instead of failing at runtime |

--- a/.claude/skills/home-assistant-best-practices/references/dashboard-cards.md
+++ b/.claude/skills/home-assistant-best-practices/references/dashboard-cards.md
@@ -1,0 +1,37 @@
+# Dashboard Card Types
+
+Home Assistant provides 39 built-in card types. For card-specific documentation, fetch from GitHub on demand.
+
+## Available Card Types
+
+alarm-panel, area, button, calendar, clock, conditional, distribution, energy, entities, entity-filter, entity, gauge, glance, grid, heading, history-graph, horizontal-stack, humidifier, iframe, light, logbook, map, markdown, media-control, picture-elements, picture-entity, picture-glance, picture, plant-status, sensor, shopping-list, shortcut, statistic, statistics-graph, thermostat, tile, todo-list, vertical-stack, weather-forecast
+
+**Note:** The HA docs URL pattern also covers 4 view types (`masonry`, `panel`, `sections`, `sidebar`) — these are set at the view level via `"type"` in view config, NOT inside card arrays. See `references/dashboard-guide.md#view-types`.
+
+## Fetching Card Documentation
+
+To get detailed documentation for a specific card type, fetch from the Home Assistant docs:
+
+```
+https://raw.githubusercontent.com/home-assistant/home-assistant.io/refs/heads/current/source/_dashboards/{card_type}.markdown
+```
+
+Replace `{card_type}` with the card name from the list above (e.g., `tile`, `grid`, `button`).
+
+If the MCP server registers resource URI templates for card docs, prefer those over raw GitHub fetches.
+
+## Quick Card Selection Guide
+
+| Need | Card |
+|------|------|
+| Control any entity | `tile` (modern default) |
+| Layout multiple cards in columns | `grid` |
+| Navigation button or Assist launcher | `shortcut` (2026.5+) or `button` with `tap_action: navigate` |
+| Room overview with controls | `area` |
+| Historical data graph | `history-graph` or `statistics-graph` |
+| Sensor value display | `sensor` or `gauge` |
+| Proportional data across entities | `distribution` |
+| Show/hide cards conditionally | `conditional` |
+| Embed external page | `iframe` |
+| Rich text / instructions | `markdown` |
+| Camera or image with overlays | `picture-elements` |

--- a/.claude/skills/home-assistant-best-practices/references/dashboard-guide.md
+++ b/.claude/skills/home-assistant-best-practices/references/dashboard-guide.md
@@ -1,0 +1,614 @@
+# Dashboard Guide
+
+Patterns and decisions for designing Home Assistant Lovelace dashboards.
+
+## Table of Contents
+
+- [Dashboard Structure](#dashboard-structure)
+- [View Types](#view-types)
+- [Card Sizing and Responsive Layout](#card-sizing-and-responsive-layout)
+- [Dashboard Strategies](#dashboard-strategies)
+- [Built-in Cards](#built-in-cards)
+- [Features](#features)
+- [Badges](#badges)
+- [Actions](#actions)
+- [Custom Cards](#custom-cards)
+- [CSS Styling](#css-styling)
+- [HACS Integration](#hacs-integration)
+- [Complete Example: Multi-View Dashboard](#complete-example-multi-view-dashboard)
+- [Common Pitfalls](#common-pitfalls)
+- [Modern Best Practices](#modern-best-practices)
+- [Visual Iteration Workflow](#visual-iteration-workflow)
+
+---
+
+## Dashboard Structure
+
+```json
+{
+  "title": "My Home",
+  "icon": "mdi:home",
+  "config": {
+    "views": [
+      {
+        "title": "Overview",
+        "path": "home",
+        "type": "sections",
+        "max_columns": 4,
+        "sections": [
+          {"type": "grid", "cards": [
+            {"type": "heading", "heading": "Climate", "icon": "mdi:thermometer"},
+            ...
+          ]},
+          {"type": "grid", "cards": [
+            {"type": "heading", "heading": "Lights", "icon": "mdi:lightbulb"},
+            ...
+          ]}
+        ]
+      }
+    ]
+  }
+}
+```
+
+Section `title` is soft-deprecated (frontend source marks it `@deprecated Use heading card instead`). It still parses and renders: the frontend converts a section `title` into a prepended `heading` card on **every config load** (`checkLovelaceConfig`), in YAML mode as well as storage mode, so existing configs are not broken — don't reject or flag a user's `title`. Prefer starting each section with an explicit `heading` card for new configs. Heading cards support `heading_style` (`"title"` or `"subtitle"`), `icon`, `tap_action`, and entity `badges`.
+
+**url_path rules:**
+- New dashboards must contain a hyphen: `my-dashboard` (not `mydashboard`)
+- Use `lovelace` to target the built-in default dashboard
+- `dashboard_id`: internal identifier (returned on create, used for update/delete)
+- `url_path`: URL identifier (user-facing, used in dashboard URLs)
+
+---
+
+## View Types
+
+| Type | Use for |
+|------|---------|
+| `sections` | Most dashboards (RECOMMENDED) — grid-based, responsive |
+| `panel` | Full-screen single cards (maps, cameras, iframes) |
+| `sidebar` | Two-column layouts with primary/secondary content |
+| `masonry` | Legacy — auto-arranges cards, less control |
+
+### View Configuration
+
+```json
+{
+  "title": "View Name",
+  "path": "unique-path",
+  "type": "sections",
+  "icon": "mdi:icon",
+  "max_columns": 4,
+  "sections": [...],
+  "subview": false,
+  "badges": ["sensor.entity_id"],
+  "background": {"image": "/local/background.jpg", "opacity": 30, "size": "cover"}
+}
+```
+
+`background.image` is a plain path or media-source reference (the `url(...)` wrapper belongs only to the legacy string form of `background`); `opacity` is an integer 0–100. Badges also accept full objects: `{"type": "entity", "entity": "person.jane", "show_name": true, "color": "accent", "visibility": [...]}`.
+
+A `sections` view also supports a `header` (a markdown card plus badge positioning) and a `footer`:
+
+```json
+{
+  "header": {"layout": "responsive", "badges_position": "top", "card": {"type": "markdown", "content": "# Welcome home"}},
+  "footer": {"max_width": 600}
+}
+```
+
+`header.layout`: `start` / `center` / `responsive`; `badges_position`: `top` / `bottom`.
+
+---
+
+## Card Sizing and Responsive Layout
+
+How sections views lay out — required background for sizing cards across screen sizes:
+
+- Each section is a **12-column grid** (cell height 56px, gap 8px). Cards default to the full 12 columns.
+- Size cards with `grid_options`: `{"columns": 6, "rows": 2}`. `columns` accepts 1–12 or `"full"`; `rows` accepts a number or `"auto"`. The older `layout_options` (`grid_columns`/`grid_rows`) is deprecated — still parsed, never write it.
+- Section columns reflow by available width (viewport minus sidebar; minimum section column width is 320px), clamped to the view's `max_columns` (default 4): roughly 1 column on phones, 2 around 700px, 3 around 1050px, more as width allows. Cards never reflow *within* a section — a card's `columns` value is fixed; what changes with width is the number of section columns shown, and the grid width of spanned sections (next point).
+- A spanned section's grid widens with it: a `column_span: 2` section has a **24-column grid** (span × 12) on wide screens, but is 12 columns again once the layout collapses to one section column. Pick values that degrade well: in a `column_span: 2` section, `"columns": 6` gives 4-up on desktop and 2-up on phones; `"columns": 12` gives 2-up on desktop and full-width on phones; `"columns": "full"` is always a full row.
+- Give graph/map cards explicit `grid_options` (`"columns": "full"` plus fixed `rows`) so they are never squeezed unreadable in a shared row.
+- Responsive show/hide uses the `screen` visibility condition with any CSS media query: `{"condition": "screen", "media_query": "(max-width: 767px)"}`. These are **visibility-targeting examples you choose**, *not* section-reflow thresholds — sections reflow on content width (previous bullet), not on these fixed viewport widths. Convenient values: `(max-width: 767px)`, `(min-width: 768px) and (max-width: 1023px)`, `(min-width: 1024px)`; `(pointer: coarse)` targets touch devices.
+- View badges wrap to multiple lines on narrow screens by default; the view `header` supports `"badges_wrap": "scroll"` for a single scrollable row.
+
+---
+
+## Dashboard Strategies
+
+A **strategy** generates a dashboard (or a single view) from code instead of a static card list. The default Overview/Home dashboard an agent first encounters **is** a strategy dashboard — its raw config is just:
+
+```yaml
+strategy:
+  type: original-states   # built-in strategy; auto-generates views from current entities/areas
+views: []
+```
+
+A strategy can be set at dashboard level (`strategy:` at the top) or per view (`views: - strategy: {type: ...}`). Custom strategies use the `custom:` prefix; any extra keys are strategy-specific options. The only universal key is `type`.
+
+```yaml
+strategy:
+  type: custom:my-area-dashboard
+  # extra keys here are passed to the custom strategy
+views: []
+```
+
+**"Take control":** to convert an auto-generated strategy dashboard into a static, hand-editable one, use the dashboard's three-dots menu → **Take control**. This is **one-way** — once taken over, the dashboard no longer auto-updates as new entities/areas appear. Editing its cards directly without taking control is a common failure mode — take control first, or edit the strategy options.
+
+---
+
+## Built-in Cards
+
+| Category | Cards |
+|----------|-------|
+| **Modern Primary** | tile, area, button, grid |
+| **Container** | vertical-stack, horizontal-stack, grid |
+| **Logic** | conditional, entity-filter |
+| **Display** | sensor, history-graph, statistics-graph, gauge, energy, calendar, distribution |
+| **Legacy Control** | entity, entities, light, thermostat (use tile instead) |
+
+**Default:** Use `tile` card for most entities. Use `references/dashboard-cards.md` to look up all card types or fetch card-specific docs.
+
+### Tile Card
+
+```json
+{
+  "type": "tile",
+  "entity": "climate.bedroom",
+  "name": "Master Bedroom",
+  "icon": "mdi:thermostat",
+  "features": [
+    {"type": "target-temperature"},
+    {"type": "climate-hvac-modes", "style": "dropdown"}
+  ],
+  "tap_action": {"action": "more-info"}
+}
+```
+
+### Grid Card
+
+```json
+{
+  "type": "grid",
+  "columns": 3,
+  "square": false,
+  "cards": [
+    {"type": "tile", "entity": "light.kitchen"},
+    {"type": "tile", "entity": "light.dining"},
+    {"type": "tile", "entity": "light.hallway"}
+  ]
+}
+```
+
+In sections views, prefer per-card `grid_options` on the section's own 12-column grid (see [Card Sizing and Responsive Layout](#card-sizing-and-responsive-layout)) — it's what the drag-and-drop editor writes. A nested grid card is still useful when a group must stay N-up at every viewport width.
+
+### Heading Card
+
+The official way to label a section, replacing a bare section `title`. Supports a title/subtitle style, an icon, a tap action, and inline entity/button badges.
+
+```json
+{
+  "type": "heading",
+  "heading": "Kitchen",
+  "heading_style": "title",
+  "icon": "mdi:fridge",
+  "tap_action": {"action": "navigate", "navigation_path": "/lovelace/kitchen"},
+  "badges": [
+    {"type": "entity", "entity": "sensor.kitchen_temperature", "show_state": true},
+    {"type": "button", "icon": "mdi:lightbulb-off", "tap_action": {"action": "perform-action", "perform_action": "light.turn_off"}}
+  ]
+}
+```
+
+Use `"heading_style": "subtitle"` for sub-headers.
+
+### Markdown Card
+
+The only built-in card that renders Jinja2 templates — the go-to for computed/composite status text without a custom card.
+
+```json
+{
+  "type": "markdown",
+  "content": "Temp {{ states('sensor.living_room') }}°. Door {{ 'open' if is_state('binary_sensor.door','on') else 'closed' }}.",
+  "entity_id": ["sensor.living_room", "binary_sensor.door"]
+}
+```
+
+The card auto-detects entities referenced in the template; `entity_id` (a list) is an optional fallback for when that analysis misses some, forcing a re-render on those. `text_only: true` strips the card chrome for inline labels.
+
+### Per-Entity Graph Colors
+
+`history-graph` and `statistics-graph` cards accept a per-entity `color` via the entity object form:
+
+```json
+{
+  "type": "history-graph",
+  "entities": [
+    {"entity": "sensor.living_room_temp", "name": "Living Room", "color": "red"},
+    {"entity": "sensor.bedroom_temp", "color": "#1f77b4"}
+  ]
+}
+```
+
+`color` accepts a named color (`red`), hex (`'#ff0000'`), or `rgb(255, 0, 0)`.
+
+---
+
+## Features
+
+Quick controls available on tile, area, humidifier, and thermostat cards.
+
+| Domain | Feature types |
+|--------|--------------|
+| Climate | `climate-hvac-modes`, `climate-fan-modes`, `climate-preset-modes`, `climate-swing-modes`, `climate-swing-horizontal-modes`, `target-temperature`, `target-humidity` |
+| Light | `light-brightness`, `light-color-temp`, `light-color-favorites` |
+| Cover/Valve | `cover-open-close`, `cover-position`, `cover-position-favorite`, `cover-tilt`, `cover-tilt-position`, `cover-tilt-favorite`, `valve-open-close`, `valve-position`, `valve-position-favorite` |
+| Fan | `fan-speed`, `fan-preset-modes`, `fan-direction`, `fan-oscillate` |
+| Media | `media-player-playback` (configurable `controls`), `media-player-volume-slider`, `media-player-volume-buttons`, `media-player-source`, `media-player-sound-mode` |
+| Weather | `temperature-forecast`, `precipitation-forecast` |
+| Generic display | `trend-graph` (history sparkline; `hours_to_show`), `bar-gauge` (`min`/`max`) |
+| Generic control | `toggle`, `button` (run an action), `numeric-input` (`style`: `"buttons"`/`"slider"`), `select-options`, `counter-actions`, `date-set` |
+| Area card | `area-controls` |
+| Domain-specific | `alarm-modes`, `lock-commands`, `lock-open-door`, `vacuum-commands`, `lawn-mower-commands`, `humidifier-modes`, `humidifier-toggle`, `update-actions`, `water-heater-operation-modes` |
+
+Mode-list features accept `style`: `"dropdown"` or `"icons"`. Tile cards also support `features_position`: `"bottom"` (default) or `"inline"`.
+
+**Weather features (2026.6):** `forecast_type` (`daily`/`twice_daily`/`hourly`), `days_to_show`/`hours_to_show`, `show_labels`; `precipitation-forecast` also takes `precipitation_type` (`amount`/`probability`).
+
+**Media features:** `media-player-volume-slider` / `media-player-volume-buttons` accept `show_mute_button` (volume-buttons also `step`); `media-player-playback` `controls:` accepts transport buttons plus `volume_up`, `volume_down`, `volume_mute`, `shuffle`, `repeat`; `media-player-source` takes a `sources:` filter list and `media-player-sound-mode` a `sound_modes:` filter list.
+
+---
+
+## Badges
+
+Badges appear at the top of a view. The simple form is a list of entity IDs, but the **object form** unlocks more:
+
+```json
+{
+  "badges": [
+    "person.john",
+    {
+      "type": "entity",
+      "entity": "sensor.kitchen_temperature",
+      "show_name": true,
+      "show_state": true,
+      "color": "amber",
+      "state_content": ["state", "last_changed"]
+    }
+  ]
+}
+```
+
+- `type: entity` options: `show_name`, `show_state`, `show_icon`, `show_entity_picture`, `state_content` (`state`/`last_changed`/`last_updated`/an attribute), and per-badge `visibility`.
+- **`color` accepts a color token or hex only — not a Jinja template.**
+
+A **`type: shortcut`** badge (2026.5) is the badge-row counterpart of the shortcut card — a labelled action chip:
+
+```json
+{
+  "type": "shortcut",
+  "text": "Good night",
+  "icon": "mdi:weather-night",
+  "color": "indigo",
+  "tap_action": {"action": "perform-action", "perform_action": "script.good_night"}
+}
+```
+
+---
+
+## Actions
+
+```json
+{
+  "tap_action": {"action": "toggle"},
+  "hold_action": {"action": "more-info"},
+  "double_tap_action": {"action": "navigate", "navigation_path": "/lovelace/lights"}
+}
+```
+
+Action types: `toggle`, `perform-action`, `more-info`, `navigate`, `url`, `assist`, `none`.
+
+`perform-action` is the renamed `call-service` — existing `action: call-service` configs (and the older `service`/`service_data` keys) still work, so don't flag them as broken; write new ones with `perform-action`.
+
+```json
+{
+  "tap_action": {
+    "action": "perform-action",
+    "perform_action": "light.turn_on",
+    "target": {"entity_id": "light.kitchen"},
+    "data": {"brightness_pct": 40},
+    "confirmation": {"text": "Turn on the kitchen?"}
+  }
+}
+```
+
+Templates are not allowed inside actions — call a script instead.
+
+### Visibility Conditions
+
+Cards, sections, and badges all accept `visibility` (a list of conditions, implicitly AND-ed). Supported condition types: `state` (`state`/`state_not`), `numeric_state` (`above`/`below`), `screen` (`media_query`), `user` (`users`), `time` (`after`/`before`/`weekdays`), `location`, and nestable `and`/`or`/`not`.
+
+```json
+{
+  "visibility": [
+    {"condition": "user", "users": ["user_id_hex"]},
+    {"condition": "numeric_state", "entity": "sensor.co2", "above": 1000},
+    {"condition": "screen", "media_query": "(min-width: 1024px)"}
+  ]
+}
+```
+
+`screen` is the canonical way to show/hide cards by viewport (desktop vs. mobile).
+
+---
+
+## Custom Cards
+
+Use custom JavaScript cards when built-in cards don't support your visualization.
+
+### Minimal Custom Card
+
+```javascript
+class MyCard extends HTMLElement {
+  setConfig(config) {
+    if (!config.entity) throw new Error("Please define an entity");
+    this.config = config;
+  }
+  set hass(hass) {
+    if (!this.content) {
+      this.innerHTML = `<ha-card header="${this.config.title || 'My Card'}">
+        <div class="card-content"></div>
+      </ha-card>`;
+      this.content = this.querySelector(".card-content");
+    }
+    const state = hass.states[this.config.entity];
+    this.content.innerHTML = state ? `State: ${state.state}` : "Entity not found";
+  }
+  getCardSize() { return 2; }
+}
+customElements.define("my-card", MyCard);
+window.customCards = window.customCards || [];
+window.customCards.push({ type: "my-card", name: "My Card", description: "A custom card" });
+```
+
+Usage: `{"type": "custom:my-card", "entity": "sensor.temperature"}`
+
+For isolated styling, use Shadow DOM (`this.attachShadow({ mode: "open" })`) and scope CSS inside the shadow root.
+
+### Hosting
+
+Use the HA dashboard resource API to convert inline code to a hosted URL, then register as a dashboard resource. Size limit: ~24KB source code.
+
+### Custom Card Workflow
+
+1. Write the card JavaScript class (see Minimal Custom Card above)
+2. Register it as a dashboard resource via the HA REST API (`/api/config/lovelace/resources`) with `resource_type: "module"`
+3. Use the card in your dashboard config with the `custom:` prefix
+
+```json
+{
+  "type": "custom:quick-status-card",
+  "entity": "sensor.temperature",
+  "name": "Living Room"
+}
+```
+
+---
+
+## CSS Styling
+
+### Themes
+
+Global styling is done with HA **themes** (YAML maps of CSS variables), not raw CSS. Themes are defined under `frontend: themes:` in YAML or installed via HACS, and selected per user (profile) or per view/card with the `theme` option. Define both modes so OS dark/light switching applies cleanly to both:
+
+```yaml
+frontend:
+  themes:
+    my_theme:
+      modes:
+        dark:
+          ha-card-border-radius: "16px"
+          primary-color: "#03a9f4"
+        light:
+          ha-card-border-radius: "16px"
+          primary-color: "#0288d1"
+```
+
+### Card-mod (Per-Card Styling)
+
+Requires the `card-mod` HACS component. Use sparingly: it patches frontend internals via shadow-DOM selectors, which makes it a frequent source of breakage after HA upgrades — prefer native options and theme variables where they exist, and re-test card-mod styling after every HA update:
+
+```yaml
+type: entities
+card_mod:
+  style: |
+    ha-card {
+      --ha-card-background: teal;
+      color: var(--primary-color);
+    }
+entities:
+  - light.bed_light
+```
+
+---
+
+## HACS Integration
+
+| Use case | Solution |
+|----------|----------|
+| Popular community card | HACS — search and install via HACS API |
+| Small custom styling | Inline CSS — register via HA dashboard resource API |
+| One-off custom card | Inline module — register via HA dashboard resource API |
+| Large/complex card | HACS or filesystem (`/config/www/`) |
+
+### Finding and Installing Cards
+
+Search HACS for community cards by name/category, review repository details, then install. HACS install operations are destructive — clients will ask for user confirmation.
+
+### Popular HACS Cards
+
+- **mushroom** — Modern, clean card collection (v5+ aligns with the native tile card; its template card covers Jinja-driven icon/color/content)
+- **button-card** — Highly customizable buttons with JS templating
+- **mini-graph-card** — Compact graphs; lighter-weight than apexcharts-card
+- **card-mod** — CSS styling for any card (see upgrade caveat above)
+- **apexcharts-card** — Professional charts; heavy (ships a full charting library), best kept to dedicated analytics views
+- **layout-card** — Pre-sections layout control; superseded by sections views for new dashboards, still useful for legacy masonry views
+
+Custom cards predating sections views (early 2024) that haven't updated since are often dormant or superseded by native equivalents — check a repository's release activity before recommending it.
+
+---
+
+## Complete Example: Multi-View Dashboard
+
+```json
+{
+  "views": [
+    {
+      "title": "Overview",
+      "path": "home",
+      "type": "sections",
+      "max_columns": 4,
+      "badges": ["person.john", "person.jane"],
+      "sections": [
+        {
+          "type": "grid",
+          "cards": [{
+            "type": "heading",
+            "heading": "Quick Actions",
+            "icon": "mdi:gesture-tap-button"
+          }, {
+            "type": "grid",
+            "columns": 4,
+            "square": false,
+            "cards": [
+              {"type": "button", "name": "Lights", "icon": "mdi:lightbulb", "tap_action": {"action": "navigate", "navigation_path": "/lovelace/lights"}},
+              {"type": "button", "name": "Climate", "icon": "mdi:thermostat", "tap_action": {"action": "navigate", "navigation_path": "/lovelace/climate"}},
+              {"type": "button", "name": "Security", "icon": "mdi:shield-home", "tap_action": {"action": "navigate", "navigation_path": "/lovelace/security"}},
+              {"type": "button", "name": "Energy", "icon": "mdi:lightning-bolt", "tap_action": {"action": "navigate", "navigation_path": "/lovelace/energy"}}
+            ]
+          }]
+        },
+        {
+          "type": "grid",
+          "cards": [
+            {"type": "heading", "heading": "Favorites", "icon": "mdi:star"},
+            {"type": "tile", "entity": "light.living_room", "features": [{"type": "light-brightness"}], "grid_options": {"columns": 6}},
+            {"type": "tile", "entity": "climate.bedroom", "features": [{"type": "target-temperature"}], "grid_options": {"columns": 6}},
+            {"type": "tile", "entity": "lock.front_door", "grid_options": {"columns": 6}}
+          ]
+        }
+      ]
+    },
+    {
+      "title": "Lights",
+      "path": "lights",
+      "type": "sections",
+      "icon": "mdi:lightbulb",
+      "max_columns": 3,
+      "sections": [
+        {
+          "type": "grid",
+          "cards": [
+            {"type": "heading", "heading": "Living Room", "icon": "mdi:sofa"},
+            {"type": "tile", "entity": "light.overhead", "features": [{"type": "light-brightness"}], "grid_options": {"columns": 4}},
+            {"type": "tile", "entity": "light.lamp", "features": [{"type": "light-brightness"}], "grid_options": {"columns": 4}},
+            {"type": "tile", "entity": "light.accent", "features": [{"type": "light-color-temp"}], "grid_options": {"columns": 4}}
+          ]
+        }
+      ]
+    }
+  ]
+}
+```
+
+---
+
+## Common Pitfalls
+
+| Issue | Solution |
+|-------|----------|
+| url_path rejected | New dashboards need a hyphen: `my-dashboard` not `mydashboard`. Use `lovelace` for the default dashboard. |
+| Entity not found | Use full entity ID: `light.living_room` not `living_room` |
+| Features not working | Match feature type to entity domain (e.g., `light-brightness` only works on `light.*`) |
+| Custom card not loading | Check resource type is `module` and verify URL is accessible |
+| Card too large for inline | Use HACS or filesystem instead |
+| Section title ignored/flagged | Section `title` is deprecated — use a `heading` card as the section's first card |
+| Cards sized with `layout_options` | Deprecated — use `grid_options` (`columns`/`rows`) |
+| Map card markers show entity-name initials instead of values | `label_mode` is a **per-entity** option, not card-level: `"entities": [{"entity": "sensor.x", "label_mode": "state"}]` |
+| Cards lay out differently in spanned sections | A spanned section's grid widens with it (24 columns in a `column_span: 2` section) but is 12 when collapsed — see [Card Sizing and Responsive Layout](#card-sizing-and-responsive-layout) |
+| Map entities missing from map card | Only entities with `latitude`/`longitude` attributes are plotted — use template sensors carrying coordinates as attributes for fixed locations |
+
+---
+
+## Modern Best Practices
+
+- Use **sections** view type with grid-based layouts
+- Use **tile** cards as primary card type (replaces legacy entity/light/climate cards)
+- Size cards with per-card **`grid_options`** on the section's 12-column grid; reserve nested grid cards for groups that must stay N-up at every width
+- Create **multiple views** with explicit `path` slugs (deep-linkable; avoid single-view endless scrolling); use `subview: true` with an explicit `back_path` for drill-down views
+- Use **area** cards with navigation for hierarchical organization
+- Start sections with **heading** cards (`title`/`subtitle` styles); subtitle headings work well for inline caveats
+
+### Recent Dashboard Features (2026.2–2026.6)
+
+| Feature | Version | Details |
+|---------|---------|---------|
+| **Distribution card** | 2026.2 | Proportional horizontal bars across multiple entities (power monitoring, storage usage) |
+| **Heading button badges** | 2026.2 | `{"type": "button"}` badges on heading cards run actions inline |
+| **Section background colors** | 2026.4 | Section `background` accepts `{"color": ..., "opacity": ...}` (or `true`) |
+| **Card favorites** | 2026.4 | Light color favorites and cover position favorites display on tile/light cards |
+| **Auto-height cards** | 2026.4 | Cards auto-adjust height based on content via the layout editor |
+| **Shortcut card + badge** | 2026.5 | One-tap navigate (dashboard/view/area/device), URL, Assist, or action with smart defaults |
+| **Media player tile features** | 2026.5 | `media-player-source`, `media-player-sound-mode`, configurable playback `controls` |
+| **Weather forecast features** | 2026.6 | `temperature-forecast`, `precipitation-forecast` tile features |
+| **Per-entity graph color** | 2026.6 | `color` on each entity of `history-graph` / `statistics-graph` |
+
+**Legacy patterns to avoid:**
+- Single-view dashboards with all cards in one long scroll
+- Excessive use of vertical-stack/horizontal-stack instead of grid
+- Masonry view (auto-layout) — use sections for precise control
+- Putting all entities in generic "entities" cards
+
+---
+
+## Visual Iteration Workflow
+
+For iterative dashboard design with visual feedback, add a browser automation MCP server:
+
+### Recommended MCP Servers
+
+- **Playwright MCP** (`@anthropic/mcp-playwright`) — Take screenshots, interact with pages
+- **Puppeteer MCP** — Similar browser automation capabilities
+- **Browser DevTools MCP** — Inspect elements, debug layouts
+
+### Workflow
+
+```
+1. Create/update dashboard via the HA config API
+2. Navigate browser to dashboard URL (e.g., http://homeassistant.local:8123/lovelace/my-dashboard)
+3. Take screenshot to see current layout
+4. Analyze screenshot for issues (spacing, alignment, colors)
+5. Adjust configuration and repeat
+```
+
+### Example with Playwright MCP
+
+```
+1. Get the HA base URL from the system overview (e.g., "http://homeassistant.local:8123")
+2. Update dashboard config via the HA REST API
+3. Navigate browser to {base_url}/lovelace/{url_path}
+4. Take screenshot → analyze → adjust → repeat
+```
+
+### Benefits
+
+- See actual rendered output, not just JSON config
+- Catch visual issues (card overlap, responsive breakpoints)
+- Verify custom card styling
+- Test on different viewport sizes
+
+### Screenshot Caveats
+
+- Test at widths that cross section-column reflow points. Sections views have no fixed pixel breakpoints — column count is computed as `floor((content_width − padding + gap) / (column_min_width + gap))`, clamped to `max_columns`, where `column_min_width` defaults to 320px. So transitions land at roughly 360px (1-col), 700px (2-col), and 1050px (3-col) of **content** width (viewport minus sidebar and padding — add ~256px for an expanded sidebar to get the viewport width). Separately, any `screen` visibility conditions only prove out at the specific widths they target, so also shoot at those.
+- History-backed cards (graphs, statistics) hydrate **asynchronously over the websocket** after page load. On instances with slow recorder queries a screenshot can capture charts half-drawn — wait several seconds, or reload and re-shoot, before concluding a chart is broken. A later screenshot that renders fully means the config is fine.

--- a/.claude/skills/home-assistant-best-practices/references/device-control.md
+++ b/.claude/skills/home-assistant-best-practices/references/device-control.md
@@ -1,0 +1,439 @@
+# Device Control Patterns
+
+Best practices for controlling devices, triggering from Zigbee buttons/remotes, and structuring service calls.
+
+---
+
+## Entity ID vs Device ID
+
+### The Core Problem
+
+`device_id` is a Home Assistant internal identifier that **changes when a device is re-added** (e.g., after Zigbee mesh repair, integration re-setup, or hardware replacement). Automations using `device_id` will break silently.
+
+`entity_id` is user-controllable, stable across device re-adds, and can be renamed for clarity.
+
+### Device Triggers vs State Triggers
+
+```yaml
+# ❌ WRONG - device_id changes if device is re-added
+triggers:
+  - trigger: device
+    device_id: abc123def456
+    domain: binary_sensor
+    type: motion
+
+# ✅ RIGHT - entity_id is stable and renameable
+triggers:
+  - trigger: state
+    entity_id: binary_sensor.hallway_motion
+    to: "on"
+```
+
+### When Device ID is Acceptable
+
+The only cases where `device_id` might be acceptable:
+
+1. **Device-only triggers** - Some devices expose triggers without entities (see Zigbee section)
+2. **Temporary automations** - Quick tests you'll delete
+3. **UI-created automations** - The UI defaults to device triggers; convert to entity triggers for production
+
+---
+
+## Service Calls Best Practices
+
+### Use target: Structure
+
+Modern Home Assistant service calls use the `target:` key to specify entities, areas, or devices:
+
+```yaml
+actions:
+  - action: light.turn_on
+    target:
+      entity_id: light.living_room
+    data:
+      brightness_pct: 100
+```
+
+### Target Types
+
+| Type | Use case | Persistence |
+|------|----------|-------------|
+| `entity_id` | Specific entities | ✅ Stable (recommended) |
+| `area_id` | All entities in a room | ✅ Stable |
+| `device_id` | All entities on a device | ❌ Changes on re-add |
+
+### Multiple Targets
+
+```yaml
+# Multiple entities
+target:
+  entity_id:
+    - light.living_room
+    - light.kitchen
+    - light.bedroom
+
+# Area targeting (all lights in living room)
+target:
+  area_id: living_room
+
+# Combined (entities + areas)
+target:
+  entity_id: light.hallway
+  area_id:
+    - bedroom
+    - bathroom
+```
+
+### Template in Targets
+
+```yaml
+# Dynamic entity selection
+target:
+  entity_id: "{{ state_attr('sensor.motion_zone', 'light_entity') }}"
+
+# All lights currently on (advanced)
+target:
+  entity_id: >
+    {{ states.light
+       | selectattr('state', 'eq', 'on')
+       | map(attribute='entity_id')
+       | list }}
+```
+
+---
+
+## Zigbee Button/Remote Patterns
+
+### ZHA (Zigbee Home Automation)
+
+ZHA buttons fire `zha_event` events. Use **event triggers** with `device_ieee` (the device's IEEE address), which is **persistent** across re-adds.
+
+```yaml
+# ✅ ZHA button trigger - device_ieee is persistent
+triggers:
+  - trigger: event
+    event_type: zha_event
+    event_data:
+      device_ieee: "00:15:8d:00:07:26:f2:8a"
+      command: "toggle"
+```
+
+For a complete multi-button remote with trigger_id + choose, see `references/examples.yaml` Example 2.
+
+#### Finding ZHA Event Data
+
+1. Go to **Developer Tools → Events**
+2. Subscribe to `zha_event`
+3. Press your button
+4. Copy the `device_ieee` and `command` values
+
+### Zigbee2MQTT (Z2M)
+
+Z2M creates **MQTT device triggers** that are autodiscovered. These are acceptable because Z2M manages the device-to-trigger mapping.
+
+```yaml
+# ✅ Z2M device trigger - autodiscovered
+triggers:
+  - trigger: device
+    device_id: abc123def456  # OK for Z2M, managed by autodiscovery
+    domain: mqtt
+    type: action
+    subtype: single
+
+# Alternative: MQTT topic trigger (more explicit)
+triggers:
+  - trigger: mqtt
+    topic: "zigbee2mqtt/Bedroom Button/action"
+    payload: "single"
+```
+
+#### Z2M Device Trigger Discovery
+
+1. Open your device in **Settings → Devices**
+2. Look for available triggers under "Automations"
+3. The UI will show valid trigger types and subtypes
+
+### Z2M vs ZHA Comparison
+
+| Aspect | ZHA | Zigbee2MQTT |
+|--------|-----|-------------|
+| Trigger type | `event` trigger | `device` trigger or `mqtt` trigger |
+| Identifier | `device_ieee` (persistent) | `device_id` (autodiscovered) |
+| Event name | `zha_event` | MQTT device trigger |
+| Button actions | `command` field | `type` and `subtype` |
+
+---
+
+## Domain-Specific Patterns
+
+### Lights
+
+**Color temperature:** Always use `color_temp_kelvin` (e.g., `3000`). The legacy `color_temp` parameter (in mireds) was removed in 2026.3.
+
+```yaml
+# Turn on with brightness and transition
+actions:
+  - action: light.turn_on
+    target:
+      entity_id: light.living_room
+    data:
+      brightness_pct: 80
+      transition: 2
+      color_temp_kelvin: 3000
+
+# Turn on multiple lights differently
+actions:
+  - action: light.turn_on
+    target:
+      entity_id: light.main
+    data:
+      brightness_pct: 100
+  - action: light.turn_on
+    target:
+      entity_id: light.accent
+    data:
+      brightness_pct: 30
+      rgb_color: [255, 147, 41]
+```
+
+### Climate
+
+```yaml
+# Set temperature with HVAC mode
+actions:
+  - action: climate.set_temperature
+    target:
+      entity_id: climate.living_room
+    data:
+      temperature: 22
+      hvac_mode: heat
+
+# Set preset mode
+actions:
+  - action: climate.set_preset_mode
+    target:
+      entity_id: climate.living_room
+    data:
+      preset_mode: away
+```
+
+### Covers (Blinds/Shades)
+
+```yaml
+# Set to specific position (0 = closed, 100 = open)
+actions:
+  - action: cover.set_cover_position
+    target:
+      entity_id: cover.living_room_blinds
+    data:
+      position: 50
+
+# Tilt control
+actions:
+  - action: cover.set_cover_tilt_position
+    target:
+      entity_id: cover.living_room_blinds
+    data:
+      tilt_position: 75
+```
+
+### Media Players
+
+```yaml
+# Play media
+actions:
+  - action: media_player.play_media
+    target:
+      entity_id: media_player.living_room_speaker
+    data:
+      media_content_id: "https://example.com/audio.mp3"
+      media_content_type: music
+
+# Set volume (0.0 to 1.0)
+actions:
+  - action: media_player.volume_set
+    target:
+      entity_id: media_player.living_room_speaker
+    data:
+      volume_level: 0.5
+```
+
+### Notifications
+
+```yaml
+# Mobile app notification
+actions:
+  - action: notify.mobile_app_phone
+    data:
+      title: "Motion Detected"
+      message: "Motion in {{ trigger.to_state.attributes.friendly_name }}"
+      data:
+        tag: "motion-alert"
+        actions:
+          - action: "DISMISS"
+            title: "Dismiss"
+          - action: "VIEW_CAMERA"
+            title: "View Camera"
+
+# Persistent notification
+actions:
+  - action: notify.persistent_notification
+    data:
+      title: "Reminder"
+      message: "Check the laundry"
+      notification_id: "laundry_reminder"
+```
+
+---
+
+## Vacuum Control
+
+```yaml
+# Start cleaning
+actions:
+  - action: vacuum.start
+    target:
+      entity_id: vacuum.roborock
+
+# Return to dock
+actions:
+  - action: vacuum.return_to_base
+    target:
+      entity_id: vacuum.roborock
+
+# Clean specific areas (2026.3+ — uses HA areas, not vendor room IDs)
+# Requires mapping vacuum segments to HA areas in entity settings first
+# Supported integrations include Matter, Ecovacs, Roborock (list may grow)
+actions:
+  - action: vacuum.clean_area
+    target:
+      entity_id: vacuum.roborock
+    data:
+      area_id:
+        - kitchen
+        - living_room
+```
+
+**Prefer `vacuum.clean_area`** when the user has mapped vacuum segments to HA areas (entity settings). It works across supported integrations without vendor lock-in.
+
+**Fallback:** When the integration doesn't support `clean_area` or segments aren't mapped, use `vacuum.send_command` with integration-specific parameters:
+
+```yaml
+# Integration-specific room cleaning (fallback)
+actions:
+  - action: vacuum.send_command
+    target:
+      entity_id: vacuum.roborock
+    data:
+      command: app_segment_clean
+      params:
+        - 16  # Vendor-specific room ID
+        - 17
+```
+
+Suggest the user configure segment-to-area mapping when possible to avoid vendor lock-in.
+
+---
+
+## Response Data
+
+Some services return data. Use `response_variable` to capture it:
+
+```yaml
+actions:
+  - action: weather.get_forecasts
+    target:
+      entity_id: weather.home
+    data:
+      type: hourly
+    response_variable: forecast
+  - action: notify.mobile_app_phone
+    data:
+      message: "Tomorrow's high: {{ forecast['weather.home'].forecast[0].temperature }}°C"
+```
+
+---
+
+## Common Mistakes
+
+### ❌ Using entity_id in data instead of target
+
+```yaml
+# WRONG (deprecated)
+actions:
+  - action: light.turn_on
+    data:
+      entity_id: light.living_room
+      brightness: 255
+
+# RIGHT
+actions:
+  - action: light.turn_on
+    target:
+      entity_id: light.living_room
+    data:
+      brightness: 255
+```
+
+### ❌ Hardcoding device_id for regular devices
+
+```yaml
+# WRONG - breaks on device re-add
+actions:
+  - action: light.turn_on
+    target:
+      device_id: abc123def456
+
+# RIGHT
+actions:
+  - action: light.turn_on
+    target:
+      entity_id: light.living_room
+```
+
+### ❌ Forgetting service data structure
+
+```yaml
+# WRONG - brightness_pct at wrong level
+actions:
+  - action: light.turn_on
+    target:
+      entity_id: light.living_room
+    brightness_pct: 100
+
+# RIGHT - brightness_pct inside data
+actions:
+  - action: light.turn_on
+    target:
+      entity_id: light.living_room
+    data:
+      brightness_pct: 100
+```
+
+---
+
+## Quick Reference: Service Call Structure
+
+```yaml
+actions:
+  - action: domain.service_name   # Required
+    target:                       # Optional but recommended
+      entity_id: entity.id        # Single or list
+      area_id: area_name          # Single or list
+      device_id: device_id        # Avoid except for Z2M
+    data:                         # Service-specific parameters
+      parameter: value
+    response_variable: result     # Capture response (if needed)
+```
+
+## Quick Reference: Trigger Types for Devices
+
+| Device Type | ZHA | Zigbee2MQTT | Generic |
+|-------------|-----|-------------|---------|
+| Button/Remote | `event` (zha_event) | `device` or `mqtt` | `state` |
+| Motion sensor | `state` | `state` | `state` |
+| Door/Window | `state` | `state` | `state` |
+| Temperature | `state` or `numeric_state` | `state` or `numeric_state` | `state` or `numeric_state` |
+| Switch | `state` | `state` | `state` |
+
+Always prefer `state` triggers with `entity_id` for sensors and switches. Only use event/device triggers for stateless devices (buttons, remotes).

--- a/.claude/skills/home-assistant-best-practices/references/domain-docs.md
+++ b/.claude/skills/home-assistant-best-practices/references/domain-docs.md
@@ -1,0 +1,57 @@
+# Domain Documentation
+
+To get detailed documentation for any Home Assistant integration or entity domain, fetch from the official docs on demand.
+
+## Fetching Domain Docs
+
+```
+https://raw.githubusercontent.com/home-assistant/home-assistant.io/refs/heads/current/source/_integrations/{domain}.markdown
+```
+
+Replace `{domain}` with the integration name (e.g., `light`, `climate`, `mqtt`).
+
+If the MCP server registers resource URI templates for domain docs, prefer those over raw GitHub fetches.
+
+## Fetching Trigger, Condition, and Action Docs
+
+Since 2026.7, every purpose-specific trigger and condition — and every service action — has a dedicated doc page covering what it does, when to use it, its config shape, options, and worked examples. Fetch the page instead of guessing keys or options:
+
+```
+https://raw.githubusercontent.com/home-assistant/home-assistant.io/refs/heads/current/source/_triggers/{trigger}.markdown
+https://raw.githubusercontent.com/home-assistant/home-assistant.io/refs/heads/current/source/_conditions/{condition}.markdown
+https://raw.githubusercontent.com/home-assistant/home-assistant.io/refs/heads/current/source/_actions/{action}.markdown
+```
+
+`{trigger}`/`{condition}`/`{action}` use `<domain>.<name>` (e.g. `motion.detected`, `zone.in_zone`, `light.turn_on`). Rendered pages live at `https://www.home-assistant.io/triggers/<domain>.<name>/` (same pattern for `/conditions/` and `/actions/`). The generic trigger types (`state`, `numeric_state`, `time`, `time_pattern`, `homeassistant`) have pages in the same tree under their bare names.
+
+Caveat: some pages still show the pre-2026.7 trigger `behavior` values `any`/`last`; the current values are `each`/`first`/`all` (conditions keep `any`/`all`).
+
+## Common Domains
+
+| Domain | Description |
+|--------|-------------|
+| `light` | Light control (brightness, color, temperature) |
+| `switch` | On/off switches |
+| `climate` | HVAC and thermostat control |
+| `cover` | Blinds, shades, garage doors |
+| `fan` | Fan speed and oscillation |
+| `lock` | Door locks |
+| `media_player` | Media playback and volume |
+| `vacuum` | Robot vacuum control |
+| `sensor` | Numeric and text sensors |
+| `binary_sensor` | On/off sensors (motion, door, window) |
+| `automation` | Automation management |
+| `script` | Script management |
+| `scene` | Scene activation |
+| `input_boolean` | Toggle helpers |
+| `input_number` | Numeric input helpers |
+| `input_select` | Dropdown helpers |
+| `input_datetime` | Date/time helpers |
+| `mqtt` | MQTT broker and entities |
+| `zha` | Zigbee Home Automation |
+| `notify` | Notification services |
+| `tts` | Text-to-speech |
+| `camera` | Camera feeds and snapshots |
+| `weather` | Weather forecasts |
+| `person` | Person/presence tracking |
+| `zone` | Geographic zones |

--- a/.claude/skills/home-assistant-best-practices/references/examples.yaml
+++ b/.claude/skills/home-assistant-best-practices/references/examples.yaml
@@ -1,0 +1,326 @@
+# =============================================================================
+# Home Assistant Best Practices - Compound Examples
+# =============================================================================
+# Each example demonstrates MULTIPLE best practices working together.
+# For individual patterns, see the corresponding reference file.
+# =============================================================================
+
+# -----------------------------------------------------------------------------
+# EXAMPLE 1: Motion-Activated Light (restart mode)
+# -----------------------------------------------------------------------------
+# Demonstrates: restart mode, state trigger, native time condition, wait_for_trigger
+# Best practice: Use restart mode so re-triggering resets the timeout
+
+automation:
+  - id: motion_light_hallway
+    alias: "Hallway Motion Light"
+    description: "Turn on hallway light when motion detected, auto-off after 3 minutes"
+    mode: restart  # Re-trigger resets the timer
+
+    triggers:
+      - trigger: state
+        entity_id: binary_sensor.hallway_motion
+        to: "on"
+
+    conditions:
+      # Native time condition - no template needed
+      - condition: time
+        after: "06:00:00"
+        before: "23:00:00"
+
+    actions:
+      - action: light.turn_on
+        target:
+          entity_id: light.hallway
+        data:
+          brightness_pct: 80
+          transition: 1
+
+      # wait_for_trigger - event-driven, waits for the change
+      - wait_for_trigger:
+          - trigger: state
+            entity_id: binary_sensor.hallway_motion
+            to: "off"
+            for:
+              minutes: 3
+        timeout:
+          minutes: 10
+        continue_on_timeout: true
+
+      - action: light.turn_off
+        target:
+          entity_id: light.hallway
+        data:
+          transition: 3
+
+
+# -----------------------------------------------------------------------------
+# EXAMPLE 2: Multi-Button Remote with trigger_id
+# -----------------------------------------------------------------------------
+# Demonstrates: ZHA event trigger, device_ieee (persistent), trigger_id, choose
+# Best practice: Use device_ieee instead of device_id for ZHA
+
+  - id: bedroom_remote_control
+    alias: "Bedroom Remote Control"
+    description: "Handle single, double, and hold presses on ZHA button"
+    mode: single
+
+    triggers:
+      - trigger: event
+        event_type: zha_event
+        event_data:
+          device_ieee: "00:15:8d:00:07:26:f2:8a"  # Replace with your device
+          command: "single"
+        id: single_press
+
+      - trigger: event
+        event_type: zha_event
+        event_data:
+          device_ieee: "00:15:8d:00:07:26:f2:8a"
+          command: "double"
+        id: double_press
+
+      - trigger: event
+        event_type: zha_event
+        event_data:
+          device_ieee: "00:15:8d:00:07:26:f2:8a"
+          command: "hold"
+        id: hold
+
+    actions:
+      - choose:
+          - conditions:
+              - condition: trigger
+                id: single_press
+            sequence:
+              - action: light.toggle
+                target:
+                  entity_id: light.bedroom
+
+          - conditions:
+              - condition: trigger
+                id: double_press
+            sequence:
+              - action: light.turn_on
+                target:
+                  area_id: bedroom
+                data:
+                  brightness_pct: 100
+
+          - conditions:
+              - condition: trigger
+                id: hold
+            sequence:
+              - action: light.turn_off
+                target:
+                  area_id: bedroom
+
+
+# -----------------------------------------------------------------------------
+# EXAMPLE 3: Door Lock Notification with Queued Mode
+# -----------------------------------------------------------------------------
+# Demonstrates: queued mode, state condition with attribute, not condition, template message
+# Best practice: Use queued mode when order matters
+
+  - id: door_unlock_notification
+    alias: "Door Unlock Notification"
+    description: "Notify when door is unlocked, show who unlocked it"
+    mode: queued  # Process each unlock event in order
+    max: 10
+
+    triggers:
+      - trigger: state
+        entity_id: lock.front_door
+        to: "unlocked"
+
+    conditions:
+      # Native not + state condition with attribute check - no template
+      - condition: not
+        conditions:
+          - condition: state
+            entity_id: lock.front_door
+            attribute: changed_by
+            state: "auto_unlock"
+
+    actions:
+      - action: notify.mobile_app_phone
+        data:
+          title: "Front Door Unlocked"
+          message: "Unlocked by {{ state_attr('lock.front_door', 'changed_by') }}"
+          data:
+            tag: "door-unlock"
+
+
+# -----------------------------------------------------------------------------
+# EXAMPLE 4: Parallel Mode for Per-Entity Actions
+# -----------------------------------------------------------------------------
+# Demonstrates: parallel mode, multi-entity trigger, trigger variable in template target
+# Best practice: Use parallel mode when actions are independent per-entity
+
+  - id: window_open_climate_off
+    alias: "Turn Off Climate When Window Opens"
+    description: "Turn off climate in room when window is opened"
+    mode: parallel  # Handle multiple windows independently
+    max: 10
+
+    triggers:
+      - trigger: state
+        entity_id:
+          - binary_sensor.bedroom_window
+          - binary_sensor.living_room_window
+          - binary_sensor.kitchen_window
+        to: "on"
+
+    actions:
+      # Use trigger variable to determine which room
+      - action: climate.turn_off
+        target:
+          entity_id: >
+            {% set room = trigger.entity_id.split('.')[1].replace('_window', '') %}
+            climate.{{ room }}
+
+
+# -----------------------------------------------------------------------------
+# EXAMPLE 5: Doorbell with if/then and Native Time Condition
+# -----------------------------------------------------------------------------
+# Demonstrates: if/then action, native time condition, quiet hours logic
+# Best practice: Use if/then for simple binary, choose for multiple branches
+
+  - id: doorbell_announcement
+    alias: "Doorbell Announcement"
+    description: "Announce doorbell with different messages based on time"
+    mode: single
+
+    triggers:
+      - trigger: state
+        entity_id: binary_sensor.doorbell
+        to: "on"
+
+    actions:
+      - if:
+          - condition: time
+            after: "22:00:00"
+            before: "08:00:00"
+        then:
+          # Quiet hours - just notification
+          - action: notify.mobile_app_phone
+            data:
+              title: "Doorbell"
+              message: "Someone is at the door"
+        else:
+          # Normal hours - announce and notification
+          - action: tts.speak
+            target:
+              entity_id: tts.google_say
+            data:
+              media_player_entity_id: media_player.living_room_speaker
+              message: "Someone is at the front door"
+          - action: notify.mobile_app_phone
+            data:
+              title: "Doorbell"
+              message: "Someone is at the door"
+
+
+# -----------------------------------------------------------------------------
+# EXAMPLE 6: Script with fields, sequence, and mode
+# -----------------------------------------------------------------------------
+# Demonstrates: correct script schema (sequence not actions), fields for
+# parameterization, mode selection, area targeting, multiple service calls
+# Best practice: Use the HA config API to create scripts programmatically
+# rather than generating YAML snippets for manual file editing
+
+script:
+  good_night:
+    alias: "Good Night"
+    description: "Turn off lights, lock doors, and set thermostat for sleeping"
+    icon: mdi:weather-night
+    mode: single
+    fields:
+      sleep_temp:
+        name: Sleep Temperature
+        description: "Target temperature for sleeping"
+        selector:
+          number:
+            min: 60
+            max: 75
+            unit_of_measurement: "°F"
+        default: 68
+    sequence:
+      - action: light.turn_off
+        target:
+          area_id:
+            - living_room
+            - kitchen
+            - bedroom
+
+      - action: lock.lock
+        target:
+          entity_id:
+            - lock.front_door
+            - lock.back_door
+
+      - action: climate.set_temperature
+        target:
+          entity_id: climate.main
+        data:
+          temperature: "{{ sleep_temp }}"
+          hvac_mode: heat
+
+      - action: notify.mobile_app_phone
+        data:
+          message: "Good night! Lights off, doors locked, thermostat set to {{ sleep_temp }}°F."
+
+
+# -----------------------------------------------------------------------------
+# EXAMPLE 7: MQTT entity configuration
+# -----------------------------------------------------------------------------
+# Demonstrates: three approaches to creating MQTT entities, in order of
+# preference. The anti-pattern table says "don't tell users to edit
+# configuration.yaml for integrations" — MQTT now supports UI-based setup.
+#
+# APPROACH 1 (RECOMMENDED): MQTT Subentries via UI
+# Settings > Devices & Services > MQTT > Add MQTT device
+# Supports: sensor, switch, light, climate, cover, fan, lock, button,
+# number, select, text, alarm_control_panel, valve, water_heater, and more.
+# No restart required. Fill in state_topic, device_class, etc. in the UI.
+#
+# APPROACH 2 (PREFERRED for devices): MQTT Discovery
+# Compatible devices (ESPHome, Tasmota, Zigbee2MQTT) announce themselves
+# to the broker. HA auto-creates entities with zero manual configuration.
+# The device publishes a JSON config payload to a discovery topic:
+
+# Example discovery payload published by device to:
+# homeassistant/sensor/outdoor_temp/config
+#
+# {
+#   "name": "Outdoor Temperature",
+#   "state_topic": "home/outdoor/temperature",
+#   "unit_of_measurement": "°C",
+#   "device_class": "temperature",
+#   "state_class": "measurement",
+#   "value_template": "{{ value_json.temperature }}",
+#   "unique_id": "outdoor_temp_001",
+#   "device": {
+#     "identifiers": ["outdoor_weather_station"],
+#     "name": "Outdoor Weather Station"
+#   }
+# }
+
+# APPROACH 3 (LEGACY FALLBACK): YAML in configuration.yaml
+# Only use if subentries don't support the entity platform yet, or if the
+# user explicitly requests YAML config.
+mqtt:
+  sensor:
+    - name: "Outdoor Temperature"
+      state_topic: "home/outdoor/temperature"
+      unit_of_measurement: "°C"
+      device_class: temperature
+      state_class: measurement
+      value_template: "{{ value_json.temperature }}"
+
+  binary_sensor:
+    - name: "Garage Door"
+      state_topic: "home/garage/door"
+      payload_on: "open"
+      payload_off: "closed"
+      device_class: garage_door

--- a/.claude/skills/home-assistant-best-practices/references/helper-selection.md
+++ b/.claude/skills/home-assistant-best-practices/references/helper-selection.md
@@ -1,0 +1,1061 @@
+# Helper Selection Guide
+
+This document covers Home Assistant's built-in helpers and integrations that should be used instead of YAML template sensors or complex automations. When no dedicated helper covers your need, the **template helper** (created via the UI / config-entry flow, not YAML `template:`) is the right escape hatch — see [Template Helpers](#template-helpers).
+
+## Table of Contents
+1. [Numeric Aggregation](#numeric-aggregation) - min_max, statistics
+2. [Rate and Change](#rate-and-change) - derivative, threshold, trend
+3. [Time-Based Tracking](#time-based-tracking) - utility_meter, history_stats, integration (Riemann sum)
+4. [State Storage](#state-storage) - input_boolean, input_number, input_select, input_text, input_datetime, input_button
+5. [Counting and Timing](#counting-and-timing) - counter, timer
+6. [Scheduling](#scheduling) - schedule, time of day (tod)
+7. [Entity Grouping](#entity-grouping) - group, binary sensor groups
+8. [Probabilistic Inference](#probabilistic-inference) - bayesian
+9. [Data Smoothing](#data-smoothing) - filter
+10. [Random Values](#random-values) - random
+11. [Climate Control](#climate-control) - generic_thermostat, generic_hygrostat, mold_indicator
+12. [Domain Conversion](#domain-conversion) - switch_as_x
+13. [Template Helpers](#template-helpers) - template (escape hatch when no dedicated helper fits)
+
+## How Helpers Are Created
+
+Helpers reach Home Assistant through two different creation mechanisms — which one a helper uses determines whether you submit flat fields in a single step or step through a config flow:
+
+- **Storage-collection helpers** — created via a per-domain WebSocket collection command (`<domain>/create`, e.g. `input_boolean/create`, `counter/create`) with flat, structured fields: `input_boolean`, `input_number`, `input_select`, `input_text`, `input_datetime`, `input_button`, `counter`, `timer`, `schedule`, `zone`, `person`, `tag`. (`schedule` additionally offers an optional YAML mode.)
+- **Config-entry-flow helpers** — created through the generic config-entry flow (`config_entries/flow`, handler = the helper domain), often a multi-step flow that begins with a sub-type menu (see [Menu-Based Helpers](#menu-based-helpers)): `template`, `group`, `utility_meter`, `derivative`, `min_max`, `threshold`, `integration`, `statistics`, `trend`, `random`, `filter`, `tod`, `generic_thermostat`, `generic_hygrostat`, `switch_as_x`, `bayesian`, `mold_indicator`.
+
+## Menu-Based Helpers
+
+Several helper integrations — most prominently **`template`**, **`group`**, and **`random`** — start with a sub-type menu before showing fields. The field set isn't known until a sub-type is picked.
+
+| Helper | Sub-types (pick one first) |
+|--------|---------------------------|
+| `template` | `sensor`, `binary_sensor`, `button`, `switch`, `light`, `cover`, `fan`, `lock`, `select`, `number`, `image`, `vacuum`, `weather`, `alarm_control_panel`, `event`, `update`, `device_tracker` |
+| `group` | `binary_sensor`, `button`, `cover`, `event`, `fan`, `light`, `lock`, `media_player`, `notify`, `sensor`, `switch`, `valve` |
+| `random` | `sensor`, `binary_sensor` |
+
+Advance the menu by submitting `{"next_step_id": "<sub-type>"}` to the first step; the resulting form's fields become available in the next step. The chosen sub-type is then written into the stored config entry as `template_type` / `group_type` etc. by the integration's validator — those are storage keys, not inputs the caller submits.
+
+---
+
+## Numeric Aggregation
+
+### min_max
+
+**Use for:** Combining multiple sensors to get min, max, mean, median, sum, or last value across all of them.
+
+**Instead of:**
+```yaml
+# WRONG - Template sensor for averaging
+template:
+  - sensor:
+      - name: "Average Temperature"
+        state: >
+          {{ ((states('sensor.temp_bedroom') | float) +
+              (states('sensor.temp_living') | float) +
+              (states('sensor.temp_kitchen') | float)) / 3 }}
+```
+
+**Use this:**
+```yaml
+# RIGHT - min_max helper
+sensor:
+  - platform: min_max
+    name: "Average Temperature"
+    type: mean
+    entity_ids:
+      - sensor.temp_bedroom
+      - sensor.temp_living
+      - sensor.temp_kitchen
+```
+
+**Available types:** `min`, `max`, `mean`, `median`, `last`, `sum`
+
+**Key behaviors:**
+- Ignores `unknown` states (except `sum` which goes to unknown)
+- Returns error if unit of measurement differs between sensors
+- For spiky values, filter with statistics sensor first
+
+**Common uses:**
+- Average house temperature from multiple room sensors
+- Maximum power consumption across circuits
+- Sum of all solar panel production sensors
+
+---
+
+### statistics
+
+**Use for:** Statistical analysis over time for a single sensor (mean, median, stdev, change, variance, etc.).
+
+**Instead of:**
+```yaml
+# WRONG - Complex template tracking history
+template:
+  - sensor:
+      - name: "Temperature Change"
+        state: "{{ states('sensor.temp') | float - state_attr('sensor.temp', 'last_value') | float(0) }}"
+```
+
+**Use this:**
+```yaml
+# RIGHT - Statistics helper
+sensor:
+  - platform: statistics
+    name: "Temperature Change (5 min)"
+    entity_id: sensor.temperature
+    state_characteristic: change
+    max_age:
+      minutes: 5
+    sampling_size: 50
+```
+
+**Available characteristics:**
+- `mean`, `median`, `average_linear`, `average_step`, `average_timeless`
+- `standard_deviation`, `variance`
+- `change`, `change_second`, `change_sample`
+- `count`, `count_binary_on`, `count_binary_off`
+- `total`, `noisiness`
+- `datetime_newest`, `datetime_oldest`, `datetime_value_max`, `datetime_value_min`
+- `value_max`, `value_min`, `quantiles`
+
+**Key behaviors:**
+- Time-based (`max_age`) vs count-based (`sampling_size`) buffering
+- If using `max_age`, ensure frequent enough readings to cover the period
+- Different from Long-Term Statistics (which is automatic for sensors with `state_class`)
+
+**Common uses:**
+- Humidity change over last hour
+- Standard deviation of power readings (detect anomalies)
+- Count of motion sensor activations in last 24 hours
+
+---
+
+## Rate and Change
+
+### derivative
+
+**Use for:** Calculating rate of change over time.
+
+**Instead of:**
+```yaml
+# WRONG - Template calculating delta manually
+template:
+  - sensor:
+      - name: "Power Rate"
+        state: "{{ (states('sensor.power') | float - states('sensor.power_previous') | float) / 60 }}"
+```
+
+**Use this:**
+```yaml
+# RIGHT - Derivative helper
+sensor:
+  - platform: derivative
+    name: "Power Rate of Change"
+    source: sensor.power
+    unit_time: min
+    time_window:
+      minutes: 5
+```
+
+**Parameters:**
+- `unit_time`: s, min, h, d - determines output unit (e.g., W/min)
+- `time_window`: Smoothing window using Simple Moving Average
+- `round`: Decimal places for output
+
+**Key behaviors:**
+- Without `time_window`, calculates between consecutive updates only
+- Can show large negative spikes when source resets to 0 (total_increasing sensors)
+- Use `force_update` option if source updates infrequently
+
+**Common uses:**
+- Energy production rate (kW from kWh sensor)
+- Temperature change rate (detect HVAC efficiency)
+- Water flow rate from cumulative meter
+
+---
+
+### threshold
+
+**Use for:** Creating a binary sensor that turns on/off when a numeric sensor crosses a threshold.
+
+**Instead of:**
+```yaml
+# WRONG - Template binary sensor
+template:
+  - binary_sensor:
+      - name: "High Temperature"
+        state: "{{ states('sensor.temperature') | float > 25 }}"
+```
+
+**Use this:**
+```yaml
+# RIGHT - Threshold helper
+binary_sensor:
+  - platform: threshold
+    name: "High Temperature"
+    entity_id: sensor.temperature
+    upper: 25
+    hysteresis: 1
+```
+
+**Parameters:**
+- `upper`: Threshold for "on" when value exceeds
+- `lower`: Threshold for "on" when value drops below
+- `hysteresis`: Buffer zone to prevent rapid toggling
+
+**Hysteresis explained:**
+```
+With upper: 25 and hysteresis: 1:
+- Turns ON when value rises ABOVE 26 (25 + 1)
+- Turns OFF when value falls BELOW 24 (25 - 1)
+```
+
+**Common uses:**
+- Low battery warning (lower threshold)
+- High humidity alert
+- Air quality threshold alerts
+- Detect temperature rising/falling (use with derivative)
+
+---
+
+### trend
+
+**Use for:** A binary sensor that turns on when a numeric sensor is trending up (or down) over time — directly, without chaining `derivative` → `threshold`.
+
+**Instead of:**
+```yaml
+# WRONG - Template comparing against a stored previous value
+template:
+  - binary_sensor:
+      - name: "Temperature Rising"
+        state: "{{ states('sensor.temp') | float > state_attr('sensor.temp', 'prev') | float(0) }}"
+```
+
+**Use this:**
+```yaml
+# RIGHT - Trend helper. NOTE: `sensors:` is a MAPPING keyed by a slug (not a list)
+binary_sensor:
+  - platform: trend
+    sensors:
+      temp_rising:
+        entity_id: sensor.temperature
+        sample_duration: 1800    # seconds of history to consider
+        min_gradient: 0.001      # units per SECOND to count as a trend
+        max_samples: 120        # cap on samples kept (independent of sample_duration)
+        invert: false            # true = detect a downward trend
+```
+
+**Key behaviors:**
+- `min_gradient` is units **per second** (0.001 °/s ≈ 3.6 °/h).
+- `invert: true` detects a *downward* trend.
+- `sensors:` is a slug-keyed mapping (not a list), unlike most other `binary_sensor` platforms.
+
+**Common uses:**
+- Temperature/pressure rising or falling
+- Battery draining
+- A value drifting before it crosses a hard threshold
+
+---
+
+## Time-Based Tracking
+
+### utility_meter
+
+**Use for:** Tracking consumption with periodic resets (energy, water, gas billing cycles).
+
+**Instead of:**
+```yaml
+# WRONG - Automation with counter tracking monthly usage
+automation:
+  - alias: "Reset monthly energy"
+    triggers:
+      - trigger: time
+        at: "00:00:00"
+    conditions:
+      - "{{ now().day == 1 }}"
+    actions:
+      - action: input_number.set_value
+        target:
+          entity_id: input_number.monthly_energy
+        data:
+          value: 0
+```
+
+**Use this:**
+```yaml
+# RIGHT - Utility meter
+utility_meter:
+  daily_energy:
+    source: sensor.energy_consumption
+    cycle: daily
+  monthly_energy:
+    source: sensor.energy_consumption
+    cycle: monthly
+```
+
+**Cycle options:** `quarter-hourly`, `hourly`, `daily`, `weekly`, `monthly`, `bimonthly`, `quarterly`, `yearly`
+
+**Advanced features:**
+- **Tariffs:** Track peak/off-peak separately
+- **Offset:** Start cycle on specific day (e.g., billing date)
+- **Cron:** Custom reset schedules
+- **Delta:** For sensors that report delta values
+
+```yaml
+# Utility meter with tariffs
+utility_meter:
+  daily_energy:
+    source: sensor.energy_consumption
+    cycle: daily
+    tariffs:
+      - peak
+      - offpeak
+```
+
+Then use automation to switch tariffs:
+```yaml
+automation:
+  - alias: "Switch to peak tariff"
+    triggers:
+      - trigger: time
+        at: "07:00:00"
+    actions:
+      - action: utility_meter.select_tariff
+        target:
+          entity_id: utility_meter.daily_energy
+        data:
+          tariff: peak
+```
+
+**Common uses:**
+- Daily/monthly energy consumption
+- Water usage per billing cycle
+- Gas consumption tracking
+
+---
+
+### history_stats
+
+**Use for:** Statistics about how long/often an entity has been in a specific state.
+
+```yaml
+sensor:
+  - platform: history_stats
+    name: "Lights on today"
+    entity_id: light.living_room
+    state: "on"
+    type: time
+    start: "{{ now().replace(hour=0, minute=0, second=0) }}"
+    end: "{{ now() }}"
+```
+
+**Types:**
+- `time`: Duration in hours
+- `ratio`: Percentage of time
+- `count`: Number of state changes to the monitored state
+
+**Key behaviors:**
+- Limited by recorder's `purge_keep_days`
+- Updates when source changes or once per minute
+
+**Common uses:**
+- How long lights were on today
+- Percentage of time home was occupied
+- Count of door openings per day
+
+---
+
+### integration (Riemann sum)
+
+**Use for:** Converting power (W) to energy (kWh), flow rate to volume, etc.
+
+```yaml
+sensor:
+  - platform: integration
+    name: "Solar Energy"
+    source: sensor.solar_power
+    unit_prefix: k
+    unit_time: h
+    method: left
+    round: 2
+```
+
+**Methods:**
+- `left`: Uses previous value for interval (recommended for sparse data)
+- `right`: Uses new value for interval
+- `trapezoidal`: Averages previous and new (can overestimate with gaps)
+
+**Key behaviors:**
+- For solar/sensors with gaps, use `left` method
+- `max_sub_interval` forces updates even when source doesn't change
+
+**Common uses:**
+- Convert solar power (W) to energy production (kWh)
+- Convert water flow rate to total consumption
+- Convert gas flow to total usage
+
+---
+
+## State Storage
+
+**Pitfall — `initial` resets state on every restart:** `input_boolean`, `input_number`, `input_select`, `input_text`, and `input_datetime` all accept an `initial` field. If `initial` is present in the config, HA forces that value on every restart instead of restoring the last saved state.
+- Omit `initial` to preserve state across restarts.
+- Use `initial` only when the helper must always start at a fixed value.
+
+### input_boolean
+
+**Use for:** Toggle switches for modes, flags, and conditions.
+
+```yaml
+input_boolean:
+  guest_mode:
+    name: "Guest Mode"
+    icon: mdi:account-group
+  vacation_mode:
+    name: "Vacation Mode"
+    icon: mdi:airplane
+```
+
+**Common uses:**
+- Guest mode (disable certain automations)
+- Vacation mode
+- Manual override flags
+- Feature toggles
+
+### input_number
+
+**Use for:** Storing numeric values that can be adjusted.
+
+```yaml
+input_number:
+  target_temperature:
+    name: "Target Temperature"
+    min: 15
+    max: 30
+    step: 0.5
+    unit_of_measurement: "°C"
+    mode: slider
+```
+
+**Modes:** `slider`, `box`
+
+**Common uses:**
+- User-adjustable thresholds
+- Target temperatures
+- Timer durations
+- Brightness levels
+
+### input_select
+
+**Use for:** Dropdown selection of predefined options.
+
+```yaml
+input_select:
+  hvac_mode:
+    name: "HVAC Mode"
+    options:
+      - "auto"
+      - "cool"
+      - "heat"
+      - "off"
+    icon: mdi:thermostat
+```
+
+**Common uses:**
+- Scene selection
+- Mode selection
+- Status tracking
+- Multi-state toggles
+
+### input_text
+
+**Use for:** Storing text strings.
+
+```yaml
+input_text:
+  notification_message:
+    name: "Custom Notification"
+    min: 0
+    max: 255
+    mode: text
+```
+
+**Modes:** `text`, `password`
+
+**Common uses:**
+- Custom messages
+- Temporary storage
+- User notes
+
+### input_datetime
+
+**Use for:** Storing date and/or time values.
+
+```yaml
+input_datetime:
+  morning_alarm:
+    name: "Morning Alarm"
+    has_time: true
+    has_date: false
+  next_vacation:
+    name: "Next Vacation"
+    has_date: true
+    has_time: false
+```
+
+**Common uses:**
+- Alarm times
+- Schedule times (wake-up, lights off)
+- Future dates (vacation, events)
+
+### input_button
+
+**Use for:** Triggering automations manually.
+
+```yaml
+input_button:
+  doorbell:
+    name: "Doorbell"
+    icon: mdi:bell
+```
+
+**Common uses:**
+- Manual triggers for automations
+- Dashboard buttons
+- Test triggers
+
+---
+
+## Counting and Timing
+
+### counter
+
+**Use for:** Tracking counts with increment/decrement/reset.
+
+**Instead of:**
+```yaml
+# WRONG - input_number with automation
+input_number:
+  coffee_count:
+    min: 0
+    max: 100
+automation:
+  - alias: "Increment coffee"
+    triggers: ...
+    actions:
+      - action: input_number.set_value
+        data:
+          value: "{{ states('input_number.coffee_count') | int + 1 }}"
+```
+
+**Use this:**
+```yaml
+# RIGHT - Counter helper
+counter:
+  coffee_count:
+    name: "Coffees Today"
+    initial: 0
+    step: 1
+    minimum: 0
+    maximum: 100
+    restore: true
+```
+
+**Actions:** `counter.increment`, `counter.decrement`, `counter.reset`, `counter.set_value`
+
+**Key behaviors:**
+- `restore: true` preserves value across restarts
+- Respects min/max boundaries
+
+**Common uses:**
+- Daily counts (coffees, workouts)
+- Usage tracking
+- Sequential numbering
+
+---
+
+### timer
+
+**Use for:** Countdown timers that fire events when finished.
+
+**Instead of:**
+```yaml
+# WRONG - Delay in automation
+actions:
+  - delay:
+      minutes: 5
+  - action: notify.mobile_app
+    data:
+      message: "Timer done!"
+```
+
+**Use this for pausable/restartable timers:**
+```yaml
+# RIGHT - Timer helper
+timer:
+  laundry:
+    name: "Laundry Timer"
+    duration: "01:00:00"
+    restore: true
+```
+
+**Actions:** `timer.start`, `timer.pause`, `timer.cancel`, `timer.finish`, `timer.change`
+
+**Events fired:**
+- `timer.started`
+- `timer.paused`
+- `timer.cancelled`
+- `timer.finished`
+- `timer.restarted`
+
+**Key behaviors:**
+- Can be started with custom duration: `timer.start` with `duration: "00:30:00"`
+- `restore: true` continues timer after restart
+- Can be controlled from dashboard
+
+**Common uses:**
+- Laundry/dryer reminders
+- Cooking timers
+- Activity timers with pause/resume
+
+---
+
+## Scheduling
+
+### schedule
+
+**Use for:** Weekly on/off schedules.
+
+```yaml
+schedule:
+  work_hours:
+    name: "Work Hours"
+    monday:
+      - from: "09:00:00"
+        to: "17:00:00"
+    tuesday:
+      - from: "09:00:00"
+        to: "17:00:00"
+    # ... etc
+```
+
+**Key behaviors:**
+- Creates a binary sensor that's `on` during scheduled times
+- Can have multiple blocks per day
+- Editable via UI
+
+**Instead of:**
+```yaml
+# WRONG - Template with weekday checks
+template:
+  - binary_sensor:
+      - name: "Work Hours"
+        state: >
+          {{ now().weekday() < 5 and
+             now().hour >= 9 and
+             now().hour < 17 }}
+```
+
+**Common uses:**
+- Work hours / business hours
+- Quiet hours
+- HVAC schedules
+- Lighting schedules
+
+---
+
+### time of day (tod)
+
+**Use for:** Binary sensor based on current time (sunrise/sunset or fixed times).
+
+```yaml
+binary_sensor:
+  - platform: tod
+    name: "Morning"
+    after: "06:00"
+    before: "12:00"
+
+  - platform: tod
+    name: "Night Time"
+    after: sunset
+    after_offset: "01:00:00"
+    before: sunrise
+```
+
+**Common uses:**
+- Time-of-day modes (morning, afternoon, evening, night)
+- Daylight/darkness detection
+- Simple time-based conditions
+
+---
+
+## Entity Grouping
+
+### group
+
+**Use for:** Combining entities for collective state and control.
+
+```yaml
+group:
+  all_lights:
+    name: "All Lights"
+    entities:
+      - light.living_room
+      - light.bedroom
+      - light.kitchen
+    all: false  # ON if ANY member is on
+
+  security_sensors:
+    name: "Security Sensors"
+    entities:
+      - binary_sensor.front_door
+      - binary_sensor.back_door
+      - binary_sensor.window
+    all: true  # ON only if ALL members are on
+```
+
+**Parameters:**
+- `all: false` (default): Group is ON if ANY member is ON (OR logic)
+- `all: true`: Group is ON only if ALL members are ON (AND logic)
+
+**Key behaviors:**
+- Groups inherit the domain of their members
+- Light groups can be controlled as a single entity
+- Binary sensor groups useful for "any door open" logic
+- Created via the config-entry flow API, `group` is **menu-based**: submit `{"next_step_id": "<sub-type>"}` first (sub-types: `binary_sensor`, `button`, `cover`, `event`, `fan`, `light`, `lock`, `media_player`, `notify`, `sensor`, `switch`, `valve`), then provide `entities`. Sensor groups additionally require `type` (one of `last`, `first_available`, `max`, `mean`, `median`, `min`, `product`, `range`, `stdev`, `sum`). The stored config entry then carries `group_type` as a storage key.
+
+**Instead of:**
+```yaml
+# WRONG - Template binary sensor for any-on logic
+template:
+  - binary_sensor:
+      - name: "Any Door Open"
+        state: >
+          {{ is_state('binary_sensor.front_door', 'on') or
+             is_state('binary_sensor.back_door', 'on') }}
+```
+
+**Common uses:**
+- All lights in an area
+- Any motion sensor active
+- All doors/windows closed
+- Group control in dashboards
+
+---
+
+## Probabilistic Inference
+
+### bayesian
+
+**Use for:** Inferring an unmeasurable state (someone cooking, showering, room occupied) from several probabilistic signals — instead of hand-tuning a template with stacked `and`/`or`/threshold logic.
+
+**Use this:**
+```yaml
+binary_sensor:
+  - platform: bayesian
+    name: "Kitchen In Use"
+    prior: 0.3                  # baseline probability before any observation
+    probability_threshold: 0.5  # turns on when posterior probability exceeds this
+    observations:
+      - entity_id: binary_sensor.kitchen_motion
+        platform: state         # or numeric_state / template
+        to_state: "on"
+        prob_given_true: 0.95
+        prob_given_false: 0.33
+      - entity_id: sensor.kitchen_power
+        platform: numeric_state
+        above: 50
+        prob_given_true: 0.8
+        prob_given_false: 0.05
+```
+
+**Key behaviors:**
+- Each observation contributes `prob_given_true` / `prob_given_false`; the sensor turns on when the combined posterior probability exceeds `probability_threshold`.
+- Observation `platform` is `state`, `numeric_state` (uses `above`/`below`), or `template` (uses `value_template`).
+- **YAML uses probabilities `0..1`; the UI config flow uses percentages `0..100`** — a common mismatch.
+
+**Common uses:**
+- "Someone is cooking" / "shower running" from motion + power + humidity
+- Occupancy inference from several weak presence signals
+
+---
+
+## Data Smoothing
+
+### filter
+
+**Use for:** Smoothing noisy sensor data, throttling update frequency, or rejecting out-of-range values.
+
+**Instead of:**
+```yaml
+# WRONG - Template sensor doing manual smoothing math
+template:
+  - sensor:
+      - name: "Smoothed Power"
+        state: >
+          {% set h = states('sensor.power_history') | from_json %}
+          {{ (h | sum / h | length) | round(2) }}
+```
+
+**Use this:**
+```yaml
+# RIGHT - Filter helper (UI creates one filter per entry; YAML supports chains)
+sensor:
+  - platform: filter
+    name: "Filtered Temperature"
+    entity_id: sensor.outdoor_temp
+    filters:
+      - filter: outlier
+        window_size: 4
+        radius: 2.0
+      - filter: lowpass
+        time_constant: 10
+      - filter: time_simple_moving_average
+        window_size: "00:05"
+        precision: 2
+```
+
+**The UI config flow creates one filter per entry.** For chained pipelines (multiple filters applied in sequence), use YAML as above.
+
+**Filter types** (one per UI entry, or multiple in a YAML list):
+
+| Filter | Required | Optional | Notes |
+|--------|----------|----------|-------|
+| `lowpass` | — | `window_size` (int, default 1), `time_constant` (int, default 10) | Suppresses high-frequency noise. |
+| `outlier` | — | `window_size` (int, default 1), `radius` (float, default 2.0) | Drops samples > `radius` standard deviations from the window mean. |
+| `range` | — | `lower_bound` (float), `upper_bound` (float) | Clamps to bounds. Supply at least one. |
+| `throttle` | — | `window_size` (int, default 1) | Sample-count throttle: emit every Nth value. |
+| `time_throttle` | `window_size` (duration) | — | Time-based throttle. UI picker disables days; YAML accepts standard `cv.time_period` syntax including days. |
+| `time_simple_moving_average` | `window_size` (duration) | `type` (`last`, default) | Time-windowed SMA. Same UI-vs-YAML duration distinction as `time_throttle`. |
+
+All filters accept optional `precision` (default `2`).
+
+---
+
+## Random Values
+
+### random
+
+**Use for:** Generating random numeric or boolean values (for testing, demos, or simulated occupancy).
+
+**Instead of:**
+```yaml
+# WRONG - Template with range() / random()
+template:
+  - sensor:
+      - name: "Random Number"
+        state: "{{ range(0, 100) | random }}"
+```
+
+**Use this:**
+```yaml
+# RIGHT - Random helper (proper entity with state class, history, etc.)
+sensor:
+  - platform: random
+    name: "Random Percentage"
+    minimum: 0
+    maximum: 100
+    unit_of_measurement: "%"
+```
+
+Menu-based — pick `sensor` (numeric) or `binary_sensor` (boolean).
+
+**random → sensor**
+- Required: `name`
+- Optional: `minimum` (default `0`), `maximum` (default `20`), `device_class`, `unit_of_measurement`
+
+**random → binary_sensor**
+- Required: `name`
+- Optional: `device_class`
+
+Binary-sensor variant (boolean coin-flip — no min/max needed):
+```yaml
+binary_sensor:
+  - platform: random
+    name: "Random Boolean"
+```
+
+---
+
+## Climate Control
+
+### generic_thermostat
+
+**Use for:** Turning a switch (or fan) into a thermostat that follows a temperature sensor.
+
+```yaml
+climate:
+  - platform: generic_thermostat
+    name: "Bedroom"
+    heater: switch.bedroom_heater
+    target_sensor: sensor.bedroom_temperature
+    ac_mode: false
+    cold_tolerance: 0.3
+    hot_tolerance: 0.3
+    min_temp: 15
+    max_temp: 25
+    min_cycle_duration: "00:05:00"
+```
+
+**Parameters (config flow):**
+- Required: `name`, `heater` (switch or fan entity), `target_sensor` (temperature sensor), `ac_mode` (bool — set `true` to invert for cooling).
+- Optional: `cold_tolerance` (default `0.3`), `hot_tolerance` (default `0.3`), `min_cycle_duration`, `max_cycle_duration`, `cycle_cooldown`, `keep_alive`, `min_temp`, `max_temp`, plus a presets step (`away_temp`, `comfort_temp`, `eco_temp`, `home_temp`, `sleep_temp`, `activity_temp`).
+
+**Key behaviors:**
+- `ac_mode: true` inverts logic (heater output activates for cooling)
+- Tolerances prevent rapid cycling near the target
+- YAML platform supports `initial_hvac_mode`, `precision`, `target_temp_step` — not exposed by the UI flow
+
+---
+
+### generic_hygrostat
+
+**Use for:** Turning a switch (or fan) into a humidifier/dehumidifier controller that follows a humidity sensor.
+
+```yaml
+humidifier:
+  - platform: generic_hygrostat
+    name: "Bathroom Dehumidifier"
+    device_class: dehumidifier
+    humidifier: switch.bathroom_fan
+    target_sensor: sensor.bathroom_humidity
+    dry_tolerance: 3
+    wet_tolerance: 3
+    min_cycle_duration: "00:05:00"
+```
+
+**Parameters (config flow):**
+- Required: `name`, `device_class` (`humidifier` or `dehumidifier`), `humidifier` (switch or fan entity), `target_sensor` (humidity sensor).
+- Optional: `dry_tolerance` (default `3`), `wet_tolerance` (default `3`), `min_cycle_duration`.
+
+---
+
+### mold_indicator
+
+**Use for:** Estimating mold/condensation risk from indoor temperature + humidity vs. a cold-surface (outdoor) temperature — instead of hand-rolling a dew-point template.
+
+```yaml
+sensor:
+  - platform: mold_indicator
+    indoor_temp_sensor: sensor.indoor_temp
+    indoor_humidity_sensor: sensor.indoor_humidity
+    outdoor_temp_sensor: sensor.outdoor_temp
+    calibration_factor: 2.0
+```
+
+Outputs an estimated humidity-at-cold-surface percentage; mold risk rises above ~70%. **`calibration_factor` must be physically calibrated** to a known condensation point — it is not a value to guess.
+
+---
+
+## Domain Conversion
+
+### switch_as_x
+
+**Use for:** Exposing a `switch.*` entity as a different domain so it integrates correctly with voice assistants, dashboards, and HVAC logic.
+
+**Instead of:**
+```yaml
+# WRONG - Template light wrapping a switch
+template:
+  - light:
+      - name: "Lamp"
+        turn_on:
+          action: switch.turn_on
+          target:
+            entity_id: switch.lamp_plug
+        turn_off:
+          action: switch.turn_off
+          target:
+            entity_id: switch.lamp_plug
+        state: "{{ is_state('switch.lamp_plug', 'on') }}"
+```
+
+**Use this** (UI / config flow — no YAML equivalent):
+- `entity_id: switch.lamp_plug`
+- `target_domain: light`
+
+`switch_as_x` hides the original switch and registers a proper `light.*` entity that voice assistants and dashboards treat correctly.
+
+**Parameters:**
+- Required: `entity_id` (must be a `switch.*` entity), `target_domain` (one of `cover`, `fan`, `light`, `lock`, `siren`, `valve`).
+- Optional: `invert` (bool, default `false`) — reverses on/off semantics (useful for normally-closed contacts).
+
+UI-only — no YAML equivalent. The original switch entity is hidden once converted; the new domain entity inherits the switch's state.
+
+---
+
+## Template Helpers
+
+When no dedicated helper covers your need, use the **template helper** — created via the config-entry flow / UI, **not** YAML `template:` platform sensors. Template helpers are first-class HA helpers: UI-editable, reloadable without restarting, and visible in the helper registry.
+
+### template
+
+**Use for:** Custom sensor/binary_sensor/switch/light/etc. logic that no dedicated helper (min_max, derivative, threshold, statistics, etc.) provides.
+
+Menu-based — pick a sub-type first (see [Menu-Based Helpers](#menu-based-helpers) for the full sub-type list), then configure fields.
+
+**template → sensor**
+- Required: `name`, `state` (Jinja template returning the sensor value)
+- Optional: `unit_of_measurement`, `device_class`, `state_class`, `device_id`, `availability` (template)
+
+**template → binary_sensor**
+- Required: `name`, `state` (Jinja template returning truthy/falsy)
+- Optional: `device_class`, `device_id`, `availability` (template)
+
+**template → device_tracker** (the native replacement for the legacy `device_tracker.see` action)
+- Required: **either** `in_zones` (a list of zone entity_ids the device is considered in) **or** both `latitude` and `longitude` (templates)
+- Optional: `location_accuracy`, plus the common `name`/`unique_id`/`icon`/`picture`/`availability`/`attributes`
+- Not valid here: `location_name`, `battery_level`, `source_type`, `host_name`, `mac_address`, `gps_accuracy`
+
+Other sub-types follow the same shape — a `state` template plus domain-appropriate metadata.
+
+**Equivalent YAML platform** (for reference; prefer the helper):
+```yaml
+template:
+  - sensor:
+      - name: "Solar Net"
+        state: "{{ states('sensor.solar_production') | float - states('sensor.house_consumption') | float }}"
+        unit_of_measurement: "W"
+        device_class: power
+        state_class: measurement
+  - binary_sensor:
+      - name: "Someone Home"
+        state: "{{ is_state('person.alice','home') or is_state('person.bob','home') }}"
+        device_class: presence
+```
+
+See the [Decision Matrix](#decision-matrix) for when the template helper is the right choice vs. a dedicated helper — every pattern that has a dedicated helper (averaging, rate of change, thresholds, time-of-day, scheduling, any-on/all-on) should go through that helper first.
+
+---
+
+## Decision Matrix
+
+| Need | Helper | Not |
+|------|--------|-----|
+| Average of multiple sensors | `min_max` (type: mean) | Template with math |
+| Sum of multiple sensors | `min_max` (type: sum) | Template with math |
+| Average over time | `statistics` | Template tracking history |
+| Rate of change | `derivative` | Template calculating delta |
+| On/off at threshold | `threshold` | Template binary sensor |
+| Sensor trending up/down | `trend` | Template with derivative + threshold |
+| Consumption per period | `utility_meter` | Counter with reset automation |
+| Time in state | `history_stats` | Template tracking timestamps |
+| Power to energy | `integration` | Template approximating |
+| User toggle | `input_boolean` | - |
+| User number | `input_number` | - |
+| User selection | `input_select` | - |
+| Count events | `counter` | input_number + automation |
+| Countdown timer | `timer` | delay + input_datetime |
+| Weekly schedule | `schedule` | Template with weekday checks |
+| Time of day mode | `tod` | Template with time checks |
+| Any-on / all-on | `group` | Template binary sensor |
+| Smooth noisy sensor | `filter` | Statistics with `mean` (filter is purpose-built for this) |
+| Throttle update rate | `filter` (`throttle`/`time_throttle`) | Custom automation with delays |
+| Reject out-of-range values | `filter` (`range`) | Template with bounds check |
+| Thermostat from switch + temp sensor | `generic_thermostat` | Automation with hysteresis logic |
+| Humidifier from switch + humidity sensor | `generic_hygrostat` | Automation with hysteresis logic |
+| Mold/condensation risk from temp + humidity | `mold_indicator` | Dew-point template |
+| Infer an unmeasurable state from several signals | `bayesian` | Template with stacked and/or logic |
+| Switch presented as light/cover/lock | `switch_as_x` | Template light/cover/lock |
+| Random sensor value | `random` | Template with `range()` |
+| Custom logic no other helper covers | `template` helper (via UI flow) | YAML `template:` platform sensor |

--- a/.claude/skills/home-assistant-best-practices/references/safe-refactoring.md
+++ b/.claude/skills/home-assistant-best-practices/references/safe-refactoring.md
@@ -1,0 +1,246 @@
+# Safe Refactoring Workflow
+
+Follow this workflow whenever you modify existing Home Assistant configuration: renaming entities, replacing template sensors with helpers, converting device triggers, or restructuring automations.
+
+**Core rule:** Search all consumers BEFORE changing anything. Verify zero stale references AFTER.
+
+---
+
+## Universal Workflow
+
+### Step 1: Identify the full scope of change
+
+Answer three questions before touching anything:
+
+1. **What changes?** Entity ID, automation structure, sensor type, or trigger semantics.
+2. **What sibling entities share the same device?** Query the device to list every entity it owns (battery sensor, update entity, diagnostic button). Plan changes for all siblings together.
+   - Query the device via the HA REST API (`GET /api/states/<entity_id>`) or inspect Settings > Devices.
+3. **Rename one entity or all device entities?** Devices bundle 2-6 entities. Renaming the primary but leaving siblings with the old naming scheme creates inconsistency.
+
+### Step 2: Search ALL consumers
+
+Search every component type that references entity IDs. Do not limit searches to the component you are editing.
+
+| Component | How to search |
+|-----------|---------------|
+| Automations | Search automations for the entity ID via the HA API or grep `automations.yaml` |
+| Dashboards | Search dashboard configs for the entity ID via the HA API or grep `.storage/lovelace*`, `ui-lovelace.yaml` |
+| Scripts | grep `scripts.yaml` |
+| Scenes | grep `scenes.yaml` |
+| Config-Entry-based groups | `GET /api/config/config_entries/entry?type=config&domain=group` — members in `options.entities`; entity registry renames do NOT update these automatically (→ see Config-Entry-Groups section) |
+| Config-Entry integrations (Better Thermostat, Generic Thermostat, Generic Hygrostat, Threshold Helper, Min/Max Helper) | `GET /api/config/config_entries/entry` — scan `data` and `options` fields for the old entity ID; entity registry renames do NOT update these fields automatically (→ see Config-Entry-Data section) |
+| Other | Check AppDaemon apps, Node-RED flows, Pyscript scripts, or any custom integration that references entity IDs |
+
+Record every location found. This list becomes your update checklist for Step 4.
+
+### Step 3: Make the change
+
+Rename the entity, replace the template sensor, or restructure the automation.
+
+### Step 4: Update every consumer
+
+Work through each location from your Step 2 checklist. Update every reference to the new entity ID, helper entity, or automation structure.
+
+### Step 5: Verify
+
+1. **Search for the OLD identifier** across all component types. Expect zero results.
+   - Search for the old entity ID via the HA API or grep all config files.
+2. **Search for the NEW identifier** to confirm all expected locations reference it.
+3. **Reload or check dashboards** if entity IDs changed.
+4. **If stale references remain that you cannot update**, rename the entity back to its original ID to restore functionality, then report the blocking locations to the user.
+
+---
+
+## Entity Renames
+
+Additional requirements beyond the universal workflow:
+
+**Device-sibling discovery (Step 1):**
+HA devices bundle multiple entities. A smart plug might expose `switch.*`, `sensor.*_energy`, and `update.*`. A multi-sensor exposes motion, temperature, illuminance, and battery entities. Rename all siblings to match.
+
+Example — renaming a smart plug's entities from manufacturer defaults to room-based names:
+
+| Domain | Old entity ID | New entity ID |
+|---|---|---|
+| switch | `switch.shellyplug_s_a1b2c3d4e5f6` | `switch.office_heater` |
+| sensor | `sensor.shellyplug_s_a1b2c3d4e5f6_energy` | `sensor.office_heater_energy` |
+| update | `update.shellyplug_s_a1b2c3d4e5f6` | `update.office_heater` |
+
+**Dashboard reference locations (Step 2):**
+Dashboard cards reference entities in multiple places. Search all of these:
+
+- `entity:` field
+- `tap_action` and `hold_action` targets
+- Conditional card conditions
+- Template card Jinja2 blocks
+- `views[n].badges` — badge rows per view; badges are siblings of the cards array, not children, so any card-focused search will miss them — always search the full dashboard config
+- `views[n].header.card` — sections view only (HA 2025.3+); the view header accepts a Markdown card that supports Jinja2 templates and may contain entity references; it is a sibling of the cards array and is not reachable via card-focused search
+
+---
+
+## Helper Replacements
+
+When replacing a template sensor with a built-in helper (`min_max`, `threshold`, `derivative`):
+
+**New entity ID (Step 1):**
+The helper creates a new entity with a different entity_id. The old template sensor's entity_id stops existing. Update every consumer of the old entity_id to reference the new one.
+
+**Test equivalence (Step 5):**
+Verify the new helper produces the same values as the old template sensor. Check units, precision, and unavailable-state handling.
+
+---
+
+## Trigger Restructuring
+
+When converting `device_id` triggers to `entity_id` triggers, or replacing `wait_template` with `wait_for_trigger`:
+
+**Behavioral equivalence (Step 1):**
+`wait_for_trigger` waits for a state *change*; `wait_template` polls for *current state*. These differ when the target state is already true at wait start: `wait_for_trigger` blocks indefinitely, `wait_template` returns immediately.
+
+**Automation callers (Step 2):**
+Search for scripts or other automations that call the automation you are restructuring via `automation.trigger` or `automation.turn_on`. Renaming or splitting an automation changes its entity_id and breaks these callers.
+
+---
+
+## Config-Entry-Groups
+
+When renaming entities that are members of a HA **group** created via the UI (Config-Entry-based group, platform: `group`):
+
+**Entity registry renames do NOT update group members automatically.**
+
+Group member entity IDs are stored in `options.entities` of the group's Config Entry — not in the entity registry. A registry rename leaves the group referencing the old (now non-existent) entity ID, silently breaking it.
+
+**Detection (Step 2):**
+List all Config-Entry-based groups to get their `entry_id` values:
+
+```http
+GET /api/config/config_entries/entry?type=config&domain=group
+```
+
+> **Note:** Some HA MCP integrations may not expose all fields from the Config Entries API
+> response — in particular, `options.entities` may be absent. Use the REST endpoint above
+> to confirm current group members directly.
+
+To inspect current members of a specific group, initiate an Options Flow and read
+`suggested_value` in the returned `data_schema.entities` field:
+
+```http
+POST /api/config/config_entries/options/flow
+{"handler": "<group_config_entry_id>"}
+```
+
+> **One active flow per Config Entry:** HA allows only one active Options Flow per Config
+> Entry at a time. If you open a detection flow to read current values, abandon or complete
+> it before initiating the fix flow. To abandon:
+>
+> ```http
+> DELETE /api/config/config_entries/options/flow/<flow_id>
+> ```
+
+**Fix (Step 4):**
+After the registry rename, update group membership via the Options Flow.
+
+1. Initiate a new fix flow (the detection flow from above must be abandoned or completed
+   first). Read the current option values from `suggested_value`. Note the `flow_id`:
+
+```http
+POST /api/config/config_entries/options/flow
+{"handler": "<group_config_entry_id>"}
+```
+
+2. Submit the updated member list, preserving existing `hide_members` value.
+   Include `all` only if it was present in the step 1 `data_schema` response — only
+   `light`, `switch`, and `binary_sensor` groups support it. For all other group types
+   (fan, lock, media_player, sensor, etc.) omit `all` entirely:
+
+```http
+POST /api/config/config_entries/options/flow/<flow_id>
+{"entities": ["new.entity_id_1", "new.entity_id_2"], "hide_members": <suggested_value>}
+```
+
+   If the group type supports `all`, add it explicitly:
+
+```http
+POST /api/config/config_entries/options/flow/<flow_id>
+{"entities": ["new.entity_id_1", "new.entity_id_2"], "hide_members": <suggested_value>, "all": <suggested_value>}
+```
+
+> **Safe rule:** Always derive field presence from the step 1 `data_schema` response —
+> never hardcode fields. Submitting unknown fields may result in a validation error.
+
+**Verify (Step 5):**
+Re-initiate the Options Flow for the group's `entry_id` and confirm that `suggested_value`
+for `entities` contains only the updated entity IDs. The REST endpoint
+`GET /api/config/config_entries/entry` does not expose `options.entities` — the Options
+Flow is the only way to read current group members.
+
+
+## Config-Entry Data — Blind Spots for entity registry renames
+
+**Entity registry renames only update the Entity Registry.** Integrations that collect entity_ids during their setup flow store them in the Config Entry — not in YAML and not in the Entity Registry. A registry rename leaves these references pointing to the old (now non-existent) entity ID.
+
+**Affected integrations and storage fields:**
+
+| Integration | Storage field | Fields containing entity_ids |
+|---|---|---|
+| **Better Thermostat** | `data` (not accessible via REST — see note below) | `temperature_sensor`, `humidity_sensor`, `outdoor_sensor`, `window_sensors` |
+| Generic Thermostat | `options` | `heater`, `target_sensor` |
+| Generic Hygrostat | `options` | `humidifier`, `target_sensor` |
+| Threshold Helper | `options` | `entity_id` |
+| Min/Max Helper | `options` | `entity_ids` |
+
+**Symptom:** Integration reports "associated entity missing" or behaves incorrectly after restart.
+
+**Timing:** Patch Config-Entry data fields **before the HA restart**. An integration that starts with stale entity_ids can cause integration setup failures on restart.
+
+**Scan via REST API:**
+```http
+GET /api/config/config_entries/entry
+```
+Iterate the returned entries and check `data` and `options` fields for the old entity ID.
+
+> **Note:** Some custom integrations (including Better Thermostat) do not expose their entity references in `data` or `options` via this endpoint — the fields may appear empty even when the integration is configured. For these integrations, the REST scan will return no matches; the Fix section below documents whether an alternative fix path exists.
+
+**Fix:**
+
+For integrations that store entity_ids in `options` (Generic Thermostat, Generic Hygrostat, Threshold Helper, Min/Max Helper): use the Options Flow. See the Config-Entry-Groups section above for the full Options Flow pattern.
+
+For integrations that store entity_ids in `data` (Better Thermostat): `data` fields written during the initial Config Flow setup have no standard API for post-setup mutation — the Options Flow updates `options` only. No API-based fix path exists. Document this limitation to the user before proceeding with a rename.
+
+---
+
+
+## Storage-Mode-Dashboards (`.storage/lovelace.*`)
+
+**Entity registry renames do NOT update Lovelace storage dashboards.**
+
+**Recommended fix — no restart required:**
+
+Use the Lovelace WebSocket API (`lovelace/config` to read, `lovelace/config/save` to write):
+
+```
+1. Read dashboard config:
+   WebSocket: {"type": "lovelace/config", "url_path": "<dashboard_url_path>"}
+   Note: the default (Overview) dashboard requires `"url_path": null`; custom dashboards use their string path.
+   → returns full dashboard config (JSON)
+
+2. Replace entity IDs (Python — JSON-aware, boundary-safe):
+   def _replace_ids(obj, old_id, new_id):
+       if isinstance(obj, str): return new_id if obj == old_id else obj
+       if isinstance(obj, list): return [_replace_ids(i, old_id, new_id) for i in obj]
+       if isinstance(obj, dict): return {(new_id if k == old_id else k): _replace_ids(v, old_id, new_id) for k, v in obj.items()}
+       return obj
+   new_config = _replace_ids(config, "old.entity_id", "new.entity_id")
+   # Note: string replace on json.dumps() is not boundary-safe — it matches entity IDs
+   # that appear as JSON keys or as substrings of other strings in the serialized output.
+
+3. Write dashboard config:
+   WebSocket: {"type": "lovelace/config/save", "url_path": "<dashboard_url_path>", "config": new_config}
+   Note: use `"url_path": null` for the default (Overview) dashboard; use the string path for custom dashboards.
+   → takes effect immediately, no restart required
+```
+
+
+
+**List all storage dashboards:**
+WebSocket: `{"type": "lovelace/dashboards/list"}` → returns all dashboards with their url_path.

--- a/.claude/skills/home-assistant-best-practices/references/scenes.md
+++ b/.claude/skills/home-assistant-best-practices/references/scenes.md
@@ -1,0 +1,92 @@
+# Scenes
+
+A scene is a **saved snapshot of target entity states, applied atomically** — not a sequential script. Activating it pushes every listed entity toward its stored state at once (optionally with a transition). Use a scene to *restore a set of states*; use a script's `sequence` when you need ordered, conditional, or timed steps.
+
+## Table of Contents
+1. [Scene Config Shape](#scene-config-shape)
+2. [Activating a Scene](#activating-a-scene)
+3. [Snapshot + Restore (scene.create)](#snapshot--restore-scenecreate)
+4. [Apply States Without Storing (scene.apply)](#apply-states-without-storing-sceneapply)
+5. [Reloading Scenes](#reloading-scenes)
+
+---
+
+## Scene Config Shape
+
+```yaml
+scene:
+  - name: Romantic            # required; `id:` optional but recommended (stable unique id)
+    icon: "mdi:flower-tulip"  # optional
+    entities:
+      light.tv_back_light: "on"          # simple form: entity_id → state string
+      light.ceiling:                      # object form: state + attributes
+        state: "on"
+        brightness: 200                   # 0–255
+        color_temp_kelvin: 2700           # Kelvin — NOT color_temp/mireds (removed 2026.3)
+      climate.living_room:
+        state: "heat"
+        temperature: 21
+```
+
+- `entities` is a dict mapping `entity_id` → a state string, or an object with `state` plus the entity's attributes.
+- Light color attributes use `color_temp_kelvin` / `rgb_color` / `xy_color` / `hs_color`. The mireds-based `color_temp` (and `kelvin`/`min_mireds`/`max_mireds`) were removed in 2026.3.
+- A scene only sets the attributes you list; unlisted entities/attributes are untouched.
+- UI-created scenes live in `scenes.yaml` and snapshot the *current* state of each added entity at save time.
+
+## Activating a Scene
+
+```yaml
+actions:
+  - action: scene.turn_on
+    target:
+      entity_id: scene.romantic
+    data:
+      transition: 2.5      # optional, seconds
+```
+
+## Snapshot + Restore (scene.create)
+
+Capture live states into a transient scene, then restore them later — the canonical "save current state, do something, put it back" pattern.
+
+```yaml
+# Capture current states (transient scene — discarded on a config/scene reload)
+- action: scene.create
+  data:
+    scene_id: before_alert          # required; lowercase + underscores
+    snapshot_entities:              # capture the CURRENT state of these
+      - light.living_room
+      - light.kitchen
+    entities:                       # optionally also set explicit states
+      light.porch:
+        state: "on"
+        brightness: 255
+# ...later, restore exactly what was captured:
+- action: scene.turn_on
+  target:
+    entity_id: scene.before_alert
+```
+
+`scene.create` requires at least one of `snapshot_entities` / `entities` (they combine). The created scene is temporary and lost on a config/scene reload.
+
+## Apply States Without Storing (scene.apply)
+
+Push a one-off set of states atomically, with no `scene.*` entity created.
+
+```yaml
+- action: scene.apply
+  data:
+    entities:                       # same shape as a scene's `entities`
+      light.tv_back_light:
+        state: "on"
+        brightness: 100
+      light.ceiling: "off"
+    transition: 2.5                 # optional, seconds
+```
+
+## Reloading Scenes
+
+After editing scene YAML, apply it without restarting:
+
+```yaml
+- action: scene.reload
+```

--- a/.claude/skills/home-assistant-best-practices/references/template-guidelines.md
+++ b/.claude/skills/home-assistant-best-practices/references/template-guidelines.md
@@ -1,0 +1,642 @@
+> **Prefer a Template Helper over YAML.**
+> Before writing any `template:` block, create a Template Helper via the HA config flow (MCP tool or API) or via the UI:
+> Settings → Devices & Services → Helpers → Create Helper → Template.
+> Use `template:` YAML only when explicitly requested or when neither programmatic nor UI access is available.
+
+# Template Guidelines
+
+This document covers when templates ARE the right choice in Home Assistant, and best practices for writing reliable templates.
+
+## Table of Contents
+1. [When Templates Are Appropriate](#when-templates-are-appropriate)
+2. [When to Avoid Templates](#when-to-avoid-templates)
+3. [Template Sensor Best Practices](#template-sensor-best-practices)
+4. [Automation Template Best Practices](#automation-template-best-practices)
+5. [Common Patterns](#common-patterns)
+6. [Error Handling](#error-handling)
+7. [Performance Considerations](#performance-considerations)
+
+---
+
+## When Templates Are Appropriate
+
+Templates are the RIGHT choice when:
+
+### 1. Dynamic Service Data
+
+You need to pass dynamic values to service calls based on entity states or trigger context.
+
+```yaml
+actions:
+  - action: light.turn_on
+    target:
+      entity_id: light.bedroom
+    data:
+      brightness_pct: "{{ states('input_number.default_brightness') | int }}"
+      kelvin: "{{ 6500 if is_state('binary_sensor.daytime', 'on') else 2700 }}"
+```
+
+### 2. Dynamic Notification Messages
+
+Messages that include runtime information:
+
+```yaml
+actions:
+  - action: notify.mobile_app
+    data:
+      message: >
+        {{ trigger.to_state.name }} has been {{ trigger.to_state.state }}
+        for {{ trigger.for.total_seconds() | int // 60 }} minutes.
+```
+
+### 3. Processing Raw Data Sources
+
+MQTT, REST, and command line sensors often provide raw data that needs transformation:
+
+```yaml
+# REST sensor with JSON response
+rest:
+  - resource: "http://api.example.com/data"
+    sensor:
+      - name: "Temperature"
+        value_template: "{{ value_json.current.temperature }}"
+        unit_of_measurement: "°C"
+```
+
+### 4. Accessing Trigger Context
+
+Using `trigger.` variables in automations:
+
+```yaml
+actions:
+  - action: notify.mobile_app
+    data:
+      message: >
+        {{ trigger.to_state.name }} changed from
+        {{ trigger.from_state.state }} to {{ trigger.to_state.state }}
+```
+
+### 5. Complex String Formatting
+
+When you need formatted output that can't be achieved with native constructs:
+
+```yaml
+template:
+  - sensor:
+      - name: "Friendly Uptime"
+        state: >
+          {% set uptime = states('sensor.system_uptime') | float(0) %}
+          {% set days = (uptime // 86400) | int %}
+          {% set hours = ((uptime % 86400) // 3600) | int %}
+          {% set minutes = ((uptime % 3600) // 60) | int %}
+          {{ days }}d {{ hours }}h {{ minutes }}m
+```
+
+### 6. Attribute Extraction
+
+Creating sensors from entity attributes:
+
+```yaml
+template:
+  - sensor:
+      - name: "Current Song Artist"
+        state: "{{ state_attr('media_player.spotify', 'media_artist') }}"
+```
+
+### 7. Complex Conditional State
+
+When the state depends on multiple factors that can't be expressed with native conditions:
+
+```yaml
+template:
+  - sensor:
+      - name: "Comfort Level"
+        state: >
+          {% set temp = states('sensor.temperature') | float(20) %}
+          {% set humidity = states('sensor.humidity') | float(50) %}
+          {% if temp >= 20 and temp <= 24 and humidity >= 40 and humidity <= 60 %}
+            Comfortable
+          {% elif temp < 18 or humidity < 30 %}
+            Too Cold/Dry
+          {% elif temp > 26 or humidity > 70 %}
+            Too Hot/Humid
+          {% else %}
+            Acceptable
+          {% endif %}
+```
+
+### 8. Entity Iteration
+
+Processing multiple entities dynamically:
+
+```yaml
+template:
+  - sensor:
+      - name: "Open Windows Count"
+        state: >
+          {{ states.binary_sensor
+             | selectattr('attributes.device_class', 'eq', 'window')
+             | selectattr('state', 'eq', 'on')
+             | list
+             | count }}
+```
+
+### 9. Date/Time Calculations
+
+Time differences, formatting, and calculations:
+
+```yaml
+template:
+  - sensor:
+      - name: "Days Until Event"
+        state: >
+          {% set event_date = as_datetime(states('input_datetime.event')) %}
+          {% set today = now().replace(hour=0, minute=0, second=0, microsecond=0) %}
+          {{ ((event_date - today).days) }}
+        unit_of_measurement: "days"
+```
+
+---
+
+## When to Avoid Templates
+
+Do NOT use templates when a native alternative exists:
+
+| Don't Use Template | Use Native |
+|-------------------|------------|
+| `{{ states('x') in ['a', 'b'] }}` | `condition: state` with `state: ["a", "b"]` |
+| `{{ states('x') \| float > 25 }}` | `condition: numeric_state` with `above: 25` |
+| `{{ now().hour >= 9 }}` | `condition: time` with `after: "09:00:00"` |
+| `{{ is_state('sun.sun', 'below_horizon') }}` | `condition: sun` with `after: sunset` |
+| `wait_template: "{{ is_state(...) }}"` | `wait_for_trigger` with state trigger |
+| Template sensor summing values | `min_max` helper with `type: sum` |
+| Template binary sensor with threshold | `threshold` helper |
+| Template sensor averaging over time | `statistics` helper |
+
+See `automation-patterns.md` and `helper-selection.md` for comprehensive alternatives.
+
+---
+
+## Template Sensor Best Practices
+
+### Always Include unique_id
+
+```yaml
+template:
+  - sensor:
+      - name: "My Sensor"
+        unique_id: my_custom_sensor  # Enables UI customization
+        state: "{{ states('sensor.source') }}"
+```
+
+### Always Define Availability
+
+Prevent errors and unknown states:
+
+```yaml
+template:
+  - sensor:
+      - name: "Safe Sensor"
+        unique_id: safe_sensor
+        availability: >
+          {{ has_value('sensor.source_a') and
+             has_value('sensor.source_b') }}
+        state: >
+          {{ states('sensor.source_a') | float +
+             states('sensor.source_b') | float }}
+```
+
+### Use Appropriate Device Class
+
+Helps with unit conversion and graph display:
+
+```yaml
+template:
+  - sensor:
+      - name: "Calculated Temperature"
+        device_class: temperature
+        unit_of_measurement: "°C"
+        state_class: measurement
+        state: "{{ states('sensor.raw_temp') | float / 10 }}"
+```
+
+### Use state_class for Long-Term Statistics (Recommended for Numeric Sensors)
+
+**If long-term statistics are needed, set `state_class`.** Without it, HA writes no
+long-term statistics — the sensor will not appear in `statistics_meta` or in History graphs.
+`state_class` is optional for diagnostic or one-shot sensors where statistics are not required.
+(Verified on HA 2026.3: `statistics_meta` empty without `state_class`, entry created after adding it.)
+
+> **Energy Dashboard note:** `state_class` alone is not sufficient for Energy Dashboard
+> visibility. The sensor also needs `device_class: energy` (or `power`, `gas`, etc.) to
+> appear as a selectable source. A sensor with `state_class` but no matching `device_class`
+> will have long-term statistics but will not appear in the Energy Dashboard configuration.
+
+Also mirror `device_class` from the source sensor where applicable (e.g., `duration`, `temperature`, `energy`).
+
+```yaml
+template:
+  - sensor:
+      - name: "Power Usage"
+        device_class: power
+        unit_of_measurement: "W"
+        state_class: measurement  # enables long-term statistics (omit if not needed)
+        state: "{{ states('sensor.amps') | float * 230 }}"
+```
+
+### Use Trigger-Based for Efficiency
+
+Trigger-based templates only update when sources change:
+
+```yaml
+template:
+  - triggers:                    # Recommended plural form (HA 2024.10+)
+      - trigger: state
+        entity_id:
+          - sensor.temp_bedroom
+          - sensor.temp_living
+    sensor:
+      - name: "Average Temperature"
+        state: >
+          {% set temps = [
+            states('sensor.temp_bedroom') | float(0),
+            states('sensor.temp_living') | float(0)
+          ] %}
+          {{ (temps | sum / temps | count) | round(1) }}
+        unit_of_measurement: "°C"
+        state_class: measurement
+```
+
+**Benefits of trigger-based:**
+- Only evaluates when trigger fires (not on every state change)
+- Access to `trigger` variable
+- More efficient for complex templates
+
+### YAML Block Structure Conventions (HA 2024.10+)
+
+**Use plural keys in trigger-based template blocks.** Since HA 2024.10 the recommended syntax
+uses `triggers:` and `actions:` (plural). The singular forms still work — there is no deprecation
+and no warnings — but all official HA docs now use plural. Write new templates in plural form.
+
+**Consolidate state-based entities of the same type in one block.** Multiple state-based
+`sensor` or `binary_sensor` entries without individual triggers belong in a single block —
+not in separate blocks per entity. Trigger-based blocks (with their own `triggers:` section)
+must be separate regardless of entity type, since each block defines its own trigger context:
+
+```yaml
+# CORRECT — state-based sensors: one block, multiple entries:
+template:
+  - binary_sensor:
+      - name: "Motion Room A"
+        unique_id: motion_room_a
+        state: "{{ ... }}"
+      - name: "Motion Room B"
+        unique_id: motion_room_b
+        state: "{{ ... }}"
+
+# AVOID — state-based sensors split across separate blocks:
+template:
+  - binary_sensor:
+      - name: "Motion Room A"
+        unique_id: motion_room_a_avoid
+        state: "{{ ... }}"
+  - binary_sensor:
+      - name: "Motion Room B"
+        unique_id: motion_room_b_avoid
+        state: "{{ ... }}"
+```
+
+> **Trigger-based blocks are always separate** — a block with `triggers:` defines its own
+> update context and cannot share a block with entries of a different trigger configuration.
+> Only consolidate entries that share the same trigger context (or are all state-based).
+
+**Follow HA's 2-space indentation rule ([HA YAML Style Guide](https://developers.home-assistant.io/docs/documenting/yaml-style-guide/)).** In template blocks, list items under `sensor:` / `binary_sensor:` are indented 2 spaces relative to the key — which, combined with the `- ` sequence marker, results in 4 visual columns from the parent dash. This is the style used consistently in the official HA template integration documentation.
+
+```yaml
+# Standard — 2-space indent per level (HA Style Guide, matches official docs):
+- binary_sensor:
+    - name: "My Sensor"
+      state: "{{ ... }}"
+
+# Non-standard — compact notation (valid YAML, but absent from official HA docs):
+- binary_sensor:
+  - name: "My Sensor"
+```
+
+---
+
+## Automation Template Best Practices
+
+### Use Shorthand Syntax
+
+For template conditions, use the shorthand:
+
+```yaml
+# Shorthand (preferred)
+conditions:
+  - "{{ trigger.to_state.attributes.brightness > 100 }}"
+
+# Long form (equivalent but verbose)
+conditions:
+  - condition: template
+    value_template: "{{ trigger.to_state.attributes.brightness > 100 }}"
+```
+
+### Use Multiline Strings
+
+For readability in complex templates:
+
+```yaml
+actions:
+  - action: notify.mobile_app
+    data:
+      message: >
+        {% if is_state('binary_sensor.door', 'on') %}
+          Warning: Door is open!
+        {% else %}
+          All secure.
+        {% endif %}
+```
+
+### Access Trigger Context Properly
+
+```yaml
+automation:
+  - triggers:
+      - trigger: state
+        entity_id: light.bedroom
+    actions:
+      - action: notify.mobile_app
+        data:
+          message: >
+            Light changed from {{ trigger.from_state.state }}
+            to {{ trigger.to_state.state }}
+            Entity: {{ trigger.entity_id }}
+            Brightness: {{ trigger.to_state.attributes.brightness | default('N/A') }}
+```
+
+---
+
+## Common Patterns
+
+### Safe State Access
+
+Always use `states()` function, not `states.sensor.x.state`:
+
+```yaml
+# GOOD - Returns 'unknown' if entity doesn't exist
+{{ states('sensor.temperature') }}
+
+# BAD - Errors if entity doesn't exist
+{{ states.sensor.temperature.state }}
+```
+
+### Safe Numeric Conversion
+
+```yaml
+# GOOD - Default value if conversion fails
+{{ states('sensor.temperature') | float(0) }}
+
+# BAD - Errors if state is 'unavailable' or 'unknown'
+{{ states('sensor.temperature') | float }}
+```
+
+### Check for Valid State
+
+```yaml
+{% if has_value('sensor.temperature') %}
+  Temperature is {{ states('sensor.temperature') }}°C
+{% else %}
+  Temperature unavailable
+{% endif %}
+```
+
+### Multiple States Check
+
+```yaml
+{% if is_state('light.a', 'on') and is_state('light.b', 'on') %}
+  Both lights on
+{% endif %}
+```
+
+### List of States
+
+```yaml
+{% if states('alarm_control_panel.home') in ['armed_home', 'armed_away', 'armed_night'] %}
+  Alarm is armed
+{% endif %}
+```
+
+### Attribute Access with Default
+
+```yaml
+{{ state_attr('light.bedroom', 'brightness') | default(0) }}
+```
+
+### Time Since State Change
+
+```yaml
+{% set last_changed = states.binary_sensor.motion.last_changed %}
+{% set seconds = (now() - last_changed).total_seconds() %}
+{{ (seconds / 60) | round(0) }} minutes ago
+```
+
+### Filter Entities by Attribute
+
+```yaml
+{% set open_windows = states.binary_sensor
+   | selectattr('attributes.device_class', 'defined')
+   | selectattr('attributes.device_class', 'eq', 'window')
+   | selectattr('state', 'eq', 'on')
+   | list %}
+{{ open_windows | count }} windows open
+```
+
+### Iterate with Index
+
+```yaml
+{% for light in states.light %}
+  {{ loop.index }}: {{ light.name }} is {{ light.state }}
+{% endfor %}
+```
+
+### Format Lists Human-Readable
+
+```yaml
+{% set items = ['apples', 'oranges', 'bananas'] %}
+{{ items[:-1] | join(', ') }} and {{ items[-1] }}
+{# Output: apples, oranges and bananas #}
+```
+
+---
+
+## Error Handling
+
+### Default Values
+
+```yaml
+# For numeric operations
+{{ states('sensor.x') | float(default=0) }}
+{{ states('sensor.x') | int(default=-1) }}
+
+# For attribute access
+{{ state_attr('light.x', 'brightness') | default(100) }}
+
+# For entire template failures
+{{ states('sensor.missing') | default('Unknown', true) }}
+```
+
+### Availability Template
+
+```yaml
+template:
+  - sensor:
+      - name: "Calculated Value"
+        availability: "{{ has_value('sensor.input') }}"
+        state: "{{ states('sensor.input') | float * 2 }}"
+```
+
+### Check Before Use
+
+```yaml
+{% if is_state_attr('media_player.tv', 'is_volume_muted', false) %}
+  Volume: {{ state_attr('media_player.tv', 'volume_level') | float * 100 }}%
+{% else %}
+  Muted
+{% endif %}
+```
+
+### Handle None Attributes
+
+```yaml
+{% set attr = state_attr('sensor.x', 'some_attr') %}
+{% if attr is not none %}
+  Attribute value: {{ attr }}
+{% else %}
+  Attribute not available
+{% endif %}
+```
+
+---
+
+## Performance Considerations
+
+### Avoid Expensive Operations in Value Templates
+
+Templates in `value_template` for sensors update on EVERY state change of the source entity.
+
+```yaml
+# EXPENSIVE - Runs on every source state change
+template:
+  - sensor:
+      - name: "Expensive Sensor"
+        state: >
+          {% for entity in states %}  {# Iterates ALL entities #}
+            ...
+          {% endfor %}
+```
+
+> The legacy per-domain template-sensor form (`sensor:` → `- platform:` → `sensors:` → `value_template:`, i.e. a `template` platform nested under a domain key) was **removed in HA 2026.6** and no longer loads. Use the top-level `template:` integration key with `state:`, as above.
+
+### Use Trigger-Based Templates for Complex Logic
+
+```yaml
+# EFFICIENT - Only runs when specified triggers fire
+template:
+  - triggers:
+      - trigger: time_pattern
+        minutes: "/5"  # Every 5 minutes
+    sensor:
+      - name: "Complex Calculation"
+        state: >
+          {% set total = 0 %}
+          {% for sensor in states.sensor | selectattr('attributes.device_class', 'eq', 'energy') %}
+            {% set total = total + states(sensor.entity_id) | float(0) %}
+          {% endfor %}
+          {{ total }}
+```
+
+### Cache Complex Calculations
+
+If you need the same value in multiple places, create one template sensor and reference it:
+
+```yaml
+# ONE template sensor
+template:
+  - sensor:
+      - name: "House Occupancy Count"
+        state: >
+          {{ states.person | selectattr('state', 'eq', 'home') | list | count }}
+
+# Reference it elsewhere
+automation:
+  - condition: numeric_state
+    entity_id: sensor.house_occupancy_count
+    above: 0
+```
+
+### Use Variables for Repeated Access
+
+```yaml
+{% set temp = states('sensor.temperature') | float(0) %}
+{% set humidity = states('sensor.humidity') | float(0) %}
+
+{% if temp > 25 and humidity > 70 %}
+  Hot and humid
+{% elif temp > 25 %}
+  Hot (temp: {{ temp }}°C)
+{% endif %}
+```
+
+---
+
+## Quick Reference: Functions and Filters
+
+### State Functions
+
+| Function | Purpose |
+|----------|---------|
+| `states('entity_id')` | Get entity state (string) |
+| `state_attr('entity_id', 'attr')` | Get attribute value |
+| `is_state('entity_id', 'state')` | Check if entity has state |
+| `is_state_attr('entity_id', 'attr', 'value')` | Check attribute value |
+| `has_value('entity_id')` | True if not unknown/unavailable |
+| `entity_name('entity_id')` | Get entity display name; preferred over `friendly_name` attribute (2026.4+) |
+| `state_attr_translated('entity_id', 'attr')` | Get translated attribute value, e.g., fan modes, HVAC actions (2026.4+) |
+
+### Common Filters
+
+| Filter | Purpose |
+|--------|---------|
+| `float(default)` | Convert to float |
+| `int(default)` | Convert to int |
+| `round(precision)` | Round number |
+| `default(value)` | Provide fallback |
+| `timestamp_custom(format)` | Format timestamp |
+| `from_json` | Parse JSON string |
+| `to_json` | Convert to JSON string |
+| `regex_match(pattern)` | Regex match |
+| `regex_replace(find, replace)` | Regex replace |
+
+### Time Functions
+
+| Function | Purpose |
+|----------|---------|
+| `now()` | Current datetime |
+| `utcnow()` | Current UTC datetime |
+| `today_at('HH:MM')` | Today at specific time |
+| `as_timestamp(dt)` | Convert to Unix timestamp |
+| `as_datetime(ts)` | Convert from timestamp |
+| `as_timedelta(string)` | Parse duration string |
+
+### Collection Filters
+
+| Filter | Purpose |
+|--------|---------|
+| `selectattr('attr', 'eq', 'value')` | Filter by attribute |
+| `rejectattr('attr', 'eq', 'value')` | Exclude by attribute |
+| `map(attribute='state')` | Extract attribute from list |
+| `list` | Convert to list |
+| `count` | Count items |
+| `first` / `last` | Get first/last item |
+| `sum` / `min` / `max` | Aggregate values |

--- a/.claude/skills/home-assistant-best-practices/references/yaml-only-integrations.md
+++ b/.claude/skills/home-assistant-best-practices/references/yaml-only-integrations.md
@@ -1,0 +1,28 @@
+# YAML-Only Integrations
+
+Use managed YAML config editing (with backup, validation, and `check_config` verification) for integrations that have no config flow and no REST/WebSocket API for creation.
+
+This does NOT apply to:
+
+- Automations/scripts/scenes (use config APIs)
+- `.storage/` files (use REST/WebSocket APIs)
+- UI-configured integrations and helpers (config flow): `input_*` helpers, the UI Group Helper (Settings → Devices & Services → Helpers → Group), and most modern notify integrations
+
+Old-style YAML `group:` blocks are still YAML-only and appear in the table below — only the UI Group Helper is excluded.
+
+For sending notifications, prefer config-flow notify integrations (Mobile App, Telegram, etc.) and invoke them via their `notify.<integration_name>` action (e.g. `notify.mobile_app_phone`) from automations — not a YAML `notify:` platform definition.
+
+## YAML-Only Integration Types
+
+| Integration type | Post-edit action | Notes |
+|---|---|---|
+| `template` | `template.reload` | Simple template entities: prefer the UI Template Helper. Trigger-based templates and multi-entity blocks (shared triggers/variables) still require YAML. |
+| `command_line` | `command_line.reload` | Sensors, switches, binary sensors via shell commands |
+| `rest` | `rest.reload` | REST sensors, binary sensors |
+| `shell_command` | `shell_command.reload` | Named shell command definitions |
+| `mqtt` (platform-based) | `mqtt.reload` | Platform-style `mqtt:` sensors/switches. MQTT Discovery and MQTT device config entries are non-YAML alternatives for auto-published devices |
+| `group` (YAML-defined) | `group.reload` | Old-style YAML groups. Prefer the UI Group Helper (Settings → Devices & Services → Helpers → Group) for new groups |
+| `sensor` / `binary_sensor` (platform-style) | `homeassistant.restart` | Platform-style YAML — a top-level `sensor:` (or `binary_sensor:`) key with a block sequence of `- platform: <name>` entries — for platforms without a config flow. Many platforms now have config flows — check the integration's docs before assuming YAML is required |
+| `switch` / `light` / `fan` / `cover` / `climate` (platform-style) | `homeassistant.restart` | Platform-style YAML — a top-level `switch:` / `light:` / etc. key with a block sequence of `- platform: <name>` entries — only for platforms that have no config flow. Check the integration's docs before assuming YAML is required |
+
+Confirm with the user before triggering `homeassistant.restart` — it briefly interrupts all automations and integrations.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -6,6 +6,12 @@ This is a **Home Assistant configuration repository** (not a development project
 
 **Key principle**: This is a configuration-as-code setup. Changes should be made through YAML edits, not code compilation or builds.
 
+**Best practices skill**: `.claude/skills/home-assistant-best-practices/` (vendored from
+[homeassistant-ai/skills](https://github.com/homeassistant-ai/skills)) has detailed guidance on
+native triggers/conditions vs. templates, helper selection, automation modes, entity_id vs
+device_id, Zigbee patterns, blueprints, and dashboard cards. Claude Code loads it automatically;
+consult it before writing or editing automations, scripts, scenes, blueprints, or dashboards.
+
 ## Architecture & Structure
 
 ### Core Configuration Pattern

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,3 +26,32 @@ When working with this Home Assistant configuration repository:
 - Use `yamllint *.yaml packages/*.yaml` to validate YAML syntax locally (note: full validation requires Home Assistant restart due to custom tags like `!include` and `!secret`)
 - Changes take effect after Home Assistant service restart (not done from this repository)
 - When searching for existing patterns or understanding features, check the `packages/` directory first as related config is grouped there
+
+## Live Home Assistant API access
+
+The live instance is reachable at `https://automation.houseabsolute.co.uk`. When the environment
+variable `HA_TOKEN` is set (a Home Assistant long-lived access token), you can call the REST API
+directly instead of (or in addition to) editing YAML in this repo:
+
+```bash
+# Get all entity states
+curl -sS -H "Authorization: Bearer $HA_TOKEN" \
+  https://automation.houseabsolute.co.uk/api/states
+
+# Call a service (e.g. turn on a light)
+curl -sS -X POST -H "Authorization: Bearer $HA_TOKEN" -H "Content-Type: application/json" \
+  -d '{"entity_id": "light.living_room"}' \
+  https://automation.houseabsolute.co.uk/api/services/light/turn_on
+```
+
+**Two distinct change paths — don't conflate them:**
+- Editing YAML in this repo requires a commit/push *and* an HA restart (or targeted reload) to take
+  effect, per the note above.
+- Calling the live API takes effect immediately but does **not** touch this repo — UI/API-driven
+  changes (helpers, automations created via config flow, entity renames) only show up here after
+  `gitsync.sh` next runs `git add . && git commit` inside `/config`.
+
+**Never write `$HA_TOKEN` (or any derived credential) to a file in this repo.** `gitsync.sh` runs
+`git add .` across the entire `/config` directory and auto-commits/pushes everything in it — this
+repo *is* the live HA config directory, already includes a tracked `secrets.yaml`, and has no
+secret-scanning safety net. Keep the token in the process environment only.


### PR DESCRIPTION
## Summary

- Vendors the `home-assistant-best-practices` Agent Skill from [homeassistant-ai/skills](https://github.com/homeassistant-ai/skills) (MIT-licensed, commit `191cfec`, metadata version 15) into `.claude/skills/home-assistant-best-practices/`.
- Dropped the upstream `evals/` directory — it's only used for authoring/testing the skill upstream, not for consuming it here.
- Added a `NOTICE.md` in the skill folder documenting provenance, license, and how to pull future updates.
- Pointed `.github/copilot-instructions.md` (this repo's single source of truth doc) at the new skill so it's discoverable.

## Why

This repo is a Home Assistant YAML config-as-code setup. The vendored skill gives Claude Code (and any other Agent-Skills-compatible tool) automatic guidance on native triggers/conditions vs. templates, helper selection, automation modes, `entity_id` vs `device_id`, Zigbee button patterns, blueprint authoring, and dashboard/card configuration — directly applicable to everything under `packages/`, `blueprints/`, and `dashboards/`.

## Test plan

- [x] `yamllint` not affected — no YAML config files were changed, only new Markdown/skill files and a docs edit.
- [x] Verified `.claude/skills/home-assistant-best-practices/SKILL.md` frontmatter and internal `references/*.md` links resolve correctly relative to the vendored directory.
- [ ] Confirm in a Claude Code session against this repo that the skill is picked up (trigger by asking to edit an automation).


---
_Generated by [Claude Code](https://claude.ai/code/session_01B9JH3EqH5yuKSQ87xBzmow)_