### PR TITLE
Repurpose fairy lights socket as master bedroom fan

### DIFF
--- a/FAIRY_LIGHTS_DORMANT.md
+++ b/FAIRY_LIGHTS_DORMANT.md
@@ -1,0 +1,63 @@
+# Fairy lights — dormant
+
+The living room fairy lights socket (Tasmota `LocalBytes PM`, MAC `14:08:08:69:52:69`) was
+repurposed as the **master bedroom fan** on 2026-07-26. Nothing was deleted: everything the
+fairy lights used is preserved in an inert state and can be brought back once a replacement
+socket is bought.
+
+## What the fairy lights actually did
+
+There were **no fairy-lights-specific automations**. The socket was driven entirely by:
+
+1. **Living Room area membership** — six `light.turn_on` / `light.turn_off` actions in
+   `packages/living_room_lights.yaml` (wall button, cosy button hold, cosy cycle "off" step,
+   presence restore, presence timeout) and one in `scripts.yaml` (`script.police_mode`) target
+   `area_id: living_room`. Any light in that area is picked up automatically.
+2. **One explicit scene reference** — scene `1767728852849` ("Living room cosy brighter") set
+   `light.fairy_lights_fairy_lights` to `on`.
+
+That is the complete set. Because the area targeting is membership-based rather than
+entity-based, a replacement socket placed in the Living Room area is picked up by all six
+actions with no config changes at all.
+
+## What is preserved, and where
+
+| Asset | State | Location |
+|---|---|---|
+| `switch_as_x` helper "Fairy lights" (switch → light) | Config entry `01KMRBSKG6XGC0RKBGZNPB5VKX`, **disabled** (`disabled_by: user`) | Entity registry / config entries |
+| `light.fairy_lights_fairy_lights` | Registry row retained, `disabled_by: config_entry` — this **reserves the entity ID** so it can be reused verbatim | Entity registry |
+| Scene membership | Commented out, ready to uncomment | `scenes.yaml`, scene `1767728852849` |
+
+The disabled `switch_as_x` entry still stores `entity_id: switch.tasmota_fairy_lights`, which no
+longer exists — that switch was renamed to `switch.master_bedroom_fan_socket`. This is
+deliberate: re-enabling the old entry **cannot** hijack the bedroom fan. `switch_as_x` does not
+support reconfiguration, so the entry must be deleted and recreated against the new socket.
+
+## Restoring the fairy lights
+
+1. Flash / adopt the replacement socket in Tasmota and let it appear in Home Assistant.
+2. Assign its device to the **Living Room** area and name the device `Fairy lights`.
+3. Delete the disabled `switch_as_x` config entry `01KMRBSKG6XGC0RKBGZNPB5VKX`
+   (*Settings → Devices & Services → Switch as X → "Fairy lights" → Delete*). This also frees
+   the reserved `light.fairy_lights_fairy_lights` entity ID.
+4. Create a new *Switch as X* helper: source = the new socket's `switch.*` entity,
+   target domain = `light`, title `Fairy lights`. Then rename the resulting entity to
+   `light.fairy_lights_fairy_lights` so the scene reference below matches.
+5. Uncomment the `light.fairy_lights_fairy_lights` block in `scenes.yaml` (scene
+   `1767728852849`, "Living room cosy brighter") and reload scenes
+   (*Developer Tools → YAML → Scenes*), or restart Home Assistant.
+6. Verify: activate `scene.living_room_cosy_brighter` and press the living room wall button —
+   the fairy lights should follow both.
+
+## The socket in its new role
+
+| Item | Value |
+|---|---|
+| Device | `Master bedroom fan`, area **Master bedroom** |
+| Primary entity | `fan.master_bedroom_fan` (`switch_as_x`, target domain `fan`) |
+| Underlying relay | `switch.master_bedroom_fan_socket` (hidden by the wrapper) |
+| Power / energy sensors | `sensor.master_bedroom_fan_power`, `…_energy_today`, `…_energy_total`, etc. |
+
+It is exposed as a `fan` rather than a `light` on purpose: the master bedroom's
+`light.turn_off` area actions (e.g. "Turn off all lights when everyone leaves" in
+`automations.yaml`) target the `light` domain, so the fan is not swept off with the lights.

--- a/packages/living_room_lights.yaml
+++ b/packages/living_room_lights.yaml
@@ -34,6 +34,12 @@
 #   packages). While it is off, the presence sensor neither restores a scene on entry nor
 #   turns the lights off after the no-presence timeout; the manual button controls are
 #   unaffected.
+#
+# FAIRY LIGHTS (DORMANT)
+#   The fairy lights socket was repurposed as the master bedroom fan; there is currently no
+#   fairy lights entity. The area_id: living_room targets below are membership-based, so a
+#   replacement socket added to the Living Room area is picked up automatically with no edits
+#   here. See FAIRY_LIGHTS_DORMANT.md for the full restore procedure.
 
 input_boolean:
   living_room_motion_enabled:

--- a/scenes.yaml
+++ b/scenes.yaml
@@ -935,13 +935,16 @@
       friendly_name: Living room lamp tall
       supported_features: 44
       state: 'on'
-    light.fairy_lights_fairy_lights:
-      supported_color_modes:
-      - onoff
-      color_mode: onoff
-      friendly_name: Fairy lights Fairy lights
-      supported_features: 0
-      state: 'on'
+    # DORMANT: the fairy lights socket was repurposed as the master bedroom fan
+    # (see FAIRY_LIGHTS_DORMANT.md). Uncomment once a replacement socket is
+    # wrapped as light.fairy_lights_fairy_lights again.
+    # light.fairy_lights_fairy_lights:
+    #   supported_color_modes:
+    #   - onoff
+    #   color_mode: onoff
+    #   friendly_name: Fairy lights Fairy lights
+    #   supported_features: 0
+    #   state: 'on'
   icon: mdi:desk-lamp
   metadata: {}
 - id: '1771801736357'


### PR DESCRIPTION
The living room fairy lights socket has been repurposed to run a fan in the master bedroom. The fairy lights config is left dormant rather than deleted, ready for a replacement socket.

## Live instance changes (already applied)

These were made through the HA API and are in `.storage`, so they aren't part of this diff:

| Change | Detail |
|---|---|
| `switch_as_x` "Fairy lights" helper | **Disabled**, not deleted — this keeps the `light.fairy_lights_fairy_lights` entity ID reserved |
| Device | Renamed `Fairy lights` → `Master bedroom fan`, moved Living Room → Master bedroom |
| Primary entity | New `switch_as_x` wrapper → `fan.master_bedroom_fan` (target domain `fan`) |
| Relay | `switch.tasmota_fairy_lights` → `switch.master_bedroom_fan_socket` |
| 19 sibling sensors | `sensor.tasmota_*_2` → `sensor.master_bedroom_fan_*` |

The socket is exposed as a `fan` rather than a `light` deliberately: the master bedroom's `light.turn_off` area actions (e.g. "Turn off all lights when everyone leaves") target the `light` domain, so the fan isn't swept off with the lights.

## Repo changes in this PR

- **`scenes.yaml`** — the `light.fairy_lights_fairy_lights` entry in scene `1767728852849` ("Living room cosy brighter") is commented out rather than removed, so the scene no longer references a missing entity but the settings are kept verbatim.
- **`FAIRY_LIGHTS_DORMANT.md`** — new: what was preserved, where, and the step-by-step restore procedure for when a replacement socket is bought.
- **`packages/living_room_lights.yaml`** — header note recording that the socket is gone and pointing at the restore doc.

## Note on "the old automations"

There were no fairy-lights-specific automations to disable. The socket was driven entirely by:

1. **Living Room area membership** — six `area_id: living_room` light actions in `packages/living_room_lights.yaml` plus one in `scripts.yaml`.
2. **One explicit scene reference** — the `scenes.yaml` entry above.

Because the area targeting is membership-based rather than entity-based, a replacement socket added to the Living Room area is picked up by all seven actions automatically, with no config changes needed.

## Verification

- `fan.master_bedroom_fan` is live and reporting `on` at 25 W via `sensor.master_bedroom_fan_power`.
- Old entity IDs return `Entity not found` from the API.
- Searched automations, scripts, scenes, all nine dashboards, and the energy dashboard prefs for the old entity IDs — the `scenes.yaml` entry was the only consumer, and it's now commented out.
- Both edited YAML files parse cleanly.

Once this merges, `gitsync.sh` pulls into `/config` within ~5 minutes; the scene change needs a scene reload (*Developer Tools → YAML → Scenes*) or a restart to take effect. Until then, activating "Living room cosy brighter" logs a warning about the unavailable entity.

---
_Generated by [Claude Code](https://claude.ai/code/session_01JkPY6S5zy4dFwkHhVZRHqg)_