### PR TITLE
Remove git pull from gitsync.sh to fix Git pull add-on restart race

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,11 +45,29 @@ curl -sS -X POST -H "Authorization: Bearer $HA_TOKEN" -H "Content-Type: applicat
 ```
 
 **Two distinct change paths — don't conflate them:**
-- Editing YAML in this repo requires a commit/push *and* an HA restart (or targeted reload) to take
-  effect, per the note above.
+- Editing YAML in this repo takes effect only once the change is merged and pulled onto the live
+  instance — see the sync mechanics below.
 - Calling the live API takes effect immediately but does **not** touch this repo — UI/API-driven
   changes (helpers, automations created via config flow, entity renames) only show up here after
   `gitsync.sh` next runs `git add . && git commit` inside `/config`.
+
+**How changes move between this repo and the live instance — two mechanisms, one direction each:**
+- **Push (live → repo):** `gitsync.sh`, invoked by the "Auto-commit configuration changes"
+  automation every 5 minutes, runs `git add .`, `git commit -am`, `git push` inside `/config`.
+  It captures UI/API-driven changes. It deliberately does **not** pull.
+- **Pull (repo → live):** the **Git pull add-on** watches the remote, pulls merged commits into
+  `/config`, and restarts Home Assistant when the config changed in a way that requires it. This
+  is what makes a merged PR take effect — you normally do **not** need to call a reload service
+  or restart HA yourself after merging.
+
+**Never add `git pull` back into `gitsync.sh`.** It creates a race: if `gitsync.sh` pulls the
+remote commits first, the add-on finds nothing new to pull, treats the config as unchanged, and
+skips the restart. The merged YAML then sits on disk, live-but-unapplied, until something else
+restarts HA. (This bug was live until 2026-07-26 and is why a merged scene change that day landed
+on disk without ever taking effect.)
+
+The add-on restarts only when the change warrants it, so *not* observing a restart after a merge
+is not by itself evidence that the mechanism is broken.
 
 **Never write `$HA_TOKEN` (or any derived credential) to a file in this repo.** `gitsync.sh` runs
 `git add .` across the entire `/config` directory and auto-commits/pushes everything in it — this

--- a/gitsync.sh
+++ b/gitsync.sh
@@ -6,6 +6,16 @@ echo Starting git backup...
 cd /config
 git add .
 git commit -am "Automated backup"
-git pull
+
+# Deliberately NO `git pull` here — do not add one back.
+#
+# Pulling remote changes is the Git pull add-on's job. It watches the remote and, when it
+# pulls new commits, restarts Home Assistant if the config changed in a way that needs it.
+# If this script pulls first, the add-on finds nothing new to pull, concludes the config is
+# unchanged, and skips that restart — so merged changes land on disk but are never applied.
+#
+# Consequence: the push below is rejected while the remote is ahead (e.g. just after a PR
+# merge). That is expected and self-correcting — the add-on pulls, and the next run five
+# minutes later pushes cleanly.
 git push
 echo Git sync completed


### PR DESCRIPTION
Fixes a race between `gitsync.sh` and the **Git pull** add-on that could leave merged config on disk but never applied.

## The bug

Two things were pulling from the remote into `/config`:

- the **Git pull add-on**, which watches the remote, pulls merged commits, and restarts Home Assistant when the config changed in a way that requires it;
- `gitsync.sh`, which ran `git pull` as part of its every-5-minutes commit/push cycle.

Whichever got there first won. When `gitsync.sh` pulled first, the add-on found nothing new to pull, concluded the config was unchanged, and skipped the restart. The merged YAML then sat in `/config` live-but-unapplied until something else restarted HA.

This is not hypothetical — it happened to the scene change merged in #73 earlier today. The file reached `/config` within five minutes and had no effect; it only took hold after `scene.reload` was called by hand.

## The fix

Drop `git pull` from `gitsync.sh`, leaving each mechanism with a single direction:

| Direction | Owner |
|---|---|
| live → repo (push UI/API changes out) | `gitsync.sh` |
| repo → live (pull merged changes in, restart if needed) | Git pull add-on |

A comment in the script explains why there is no pull, so it isn't reintroduced by someone tidying up later.

### Expected side effect

`git push` is now rejected while the remote is ahead — for example in the window immediately after a PR merge, before the add-on has pulled. This is expected and self-correcting: the add-on pulls, and the next run five minutes later pushes cleanly. The failed push logs an error and changes nothing.

## CLAUDE.md

Documents both mechanisms and their directions, and warns explicitly against re-adding the pull.

This supersedes the note this PR originally carried. That note was written before I had accounted for the Git pull add-on: I had checked `gitsync.sh` and the automations, found no restart, and wrongly concluded that merged changes always need a manual reload. The add-on does handle it — the restart was being suppressed by this race. The branch has been squashed so that incorrect commit message doesn't land in `master`.

## Scope

`gitsync.sh` (one line removed, comment added) and `CLAUDE.md`. No automation, entity, or config changes. `bash -n gitsync.sh` passes.