### PR TITLE
Toggle bedroom fan by holding the bedside dimmer's off button

### DIFF
--- a/packages/master_bedroom_lights.yaml
+++ b/packages/master_bedroom_lights.yaml
@@ -21,10 +21,11 @@
 # CONTROLS (behaviour is shared across both switches; the bedside one does more)
 #   Bedside switch - 4 buttons (Hue dimmer "Master bedroom wireless switch"),
 #   listed top to bottom. Each button is one fixed action - no cycling:
-#     on   (top)    -> Main ceiling lights on
-#     up   (2nd)    -> Toggle curtains/blinds (the ONLY button that touches them)
-#     down (3rd)    -> Cosy mode: main lights off, lamp on
-#     off  (bottom) -> Everything off (lamp + main lights; leaves the blinds alone)
+#     on   (top)      -> Main ceiling lights on
+#     up   (2nd)      -> Toggle curtains/blinds (the ONLY button that touches them)
+#     down (3rd)      -> Cosy mode: main lights off, lamp on
+#     off  (bottom)   -> Everything off (lamp + main lights; leaves the blinds alone)
+#     off  (hold)     -> Toggle the bedroom fan (fan.master_bedroom_fan)
 #   Door switch - 2 buttons (Aqara)
 #     right -> Smart cycle through every mode:  off -> full -> dim -> dim_low -> off
 #     left  -> Toggle curtains
@@ -189,7 +190,7 @@ automation:
   # ---------------------------------------------------------------------------
   - id: "1748385723267"
     alias: Master bedroom bedside switch
-    description: 4-button bedside Hue dimmer - main-on / blinds / cosy / all-off
+    description: 4-button bedside Hue dimmer - main-on / blinds / cosy / all-off / hold-off toggles fan
     use_blueprint:
       path: patpac9/Hue_Dimmer_Switch_Easy_Custom_Buttons.yaml
       input:
@@ -207,6 +208,11 @@ automation:
         off_released:
           - action: script.master_bedroom_off
         on_hold_released: []
+        # Bottom, held: toggle the bedroom fan
+        off_hold_released:
+          - action: fan.toggle
+            target:
+              entity_id: fan.master_bedroom_fan
 
   # ---------------------------------------------------------------------------
   # DOOR SWITCH (2 buttons) - Aqara, raw MQTT device actions.


### PR DESCRIPTION
## Summary
- Wires up `off_hold_released` (previously unused, `on_hold_released: []` was the only hold input set) on the master bedroom bedside Hue dimmer blueprint automation to call `fan.toggle` on `fan.master_bedroom_fan`.
- Holding the bottom ("off") button now toggles the bedroom fan, without disturbing its existing single-press behaviour (everything off).
- Updated the package header comment and automation `description` to document the new hold action.

## Context
`fan.master_bedroom_fan` was recently added (see `FAIRY_LIGHTS_DORMANT.md` / `780dfdb`) when the living-room fairy-lights socket was repurposed as the bedroom fan. This adds a physical control for it via the existing bedside dimmer instead of requiring the app/voice.

Note: I don't have live API access (`HA_TOKEN`) in this session, so this change needs to reach the live instance via merge + restart/reload rather than being applied directly.

## Test plan
- [x] Validated YAML loads with `python3 -c "import yaml; yaml.safe_load(...)"`
- [ ] After merge/restart, confirm the automation reloads without errors and holding the bedside switch's off button toggles `fan.master_bedroom_fan`

🤖 Generated with [Claude Code](https://claude.ai/code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01AkTTsxYfB3euomE8KgQkRX)_